### PR TITLE
Index goes over the size

### DIFF
--- a/Source/IGSIOCommon/igsioXmlUtils.h
+++ b/Source/IGSIOCommon/igsioXmlUtils.h
@@ -279,7 +279,7 @@ public:
     memberVarType tmpValue[vectorSize] = {0}; \
     if ( xmlElementVar->GetVectorAttribute(#memberVar, vectorSize, tmpValue) )  \
     { \
-      for(int i = 0; i < vectorSize+1; ++i) \
+      for(int i = 0; i < vectorSize; ++i) \
       { \
         memberVar[i] = tmpValue[i]; \
       } \


### PR DESCRIPTION
Detected by [Concurrency Code Analysis in Visual Studio 2019](https://devblogs.microsoft.com/cppblog/concurrency-code-analysis-in-visual-studio-2019/):
```text
c:\dev\plusgit\s64wp\pluslib\src\plusdatacollection\vtkplusdatasource.cxx(357): warning C6201: Index '3' is out of valid index range '0' to '2' for possibly stack allocated buffer 'tmpValue'.
c:\dev\plusgit\s64wp\pluslib\src\plusdatacollection\vtkplusdatasource.cxx(375): warning C6201: Index '3' is out of valid index range '0' to '2' for possibly stack allocated buffer 'tmpValue'.
```