### PR TITLE
Read OpenCL Volume Reconstruction Output on Demand

### DIFF
--- a/Source/VolumeReconstruction/vtkIGSIOPasteSliceIntoVolume.cxx
+++ b/Source/VolumeReconstruction/vtkIGSIOPasteSliceIntoVolume.cxx
@@ -222,6 +222,33 @@ void vtkIGSIOPasteSliceIntoVolume::PrintSelf( ostream& os, vtkIndent indent )
 //----------------------------------------------------------------------------
 vtkImageData* vtkIGSIOPasteSliceIntoVolume::GetReconstructedVolume()
 {
+#ifdef IGSIO_USE_GPU
+	if (this->OpenCLContext)
+	{
+		// Get output volume extent and pointer
+		vtkImageData* outData = this->ReconstructedVolume;
+
+		vtkIGSIOPasteSliceIntoVolumeInsertSliceParams insertionParams;
+		int* outExtent = this->OutputExtent;
+		outData->SetExtent(outExtent);
+		outData->SetOrigin(this->OutputOrigin);
+		outData->SetSpacing(this->OutputSpacing);
+		outData->AllocateScalars(this->OutputScalarMode, 1);
+
+		void* outPtr = outData->GetScalarPointerForExtent(outExtent);
+
+		insertionParams.outData = this->ReconstructedVolume;
+		insertionParams.outPtr = outPtr;
+		insertionParams.accPtr = NULL;
+		insertionParams.accOverflowCount = NULL
+
+		vtkOpenCLReadOutput(&insertionParams, this->OpenCLContext);
+	}
+
+	LOG_INFO("Reading OpenCL output");
+
+#endif
+
   return this->ReconstructedVolume;
 }
 

--- a/Source/VolumeReconstruction/vtkIGSIOPasteSliceIntoVolume.cxx
+++ b/Source/VolumeReconstruction/vtkIGSIOPasteSliceIntoVolume.cxx
@@ -230,11 +230,6 @@ vtkImageData* vtkIGSIOPasteSliceIntoVolume::GetReconstructedVolume()
 
 		vtkIGSIOPasteSliceIntoVolumeInsertSliceParams insertionParams;
 		int* outExtent = this->OutputExtent;
-		outData->SetExtent(outExtent);
-		outData->SetOrigin(this->OutputOrigin);
-		outData->SetSpacing(this->OutputSpacing);
-		outData->AllocateScalars(this->OutputScalarMode, 1);
-
 		void* outPtr = outData->GetScalarPointerForExtent(outExtent);
 
 		insertionParams.outData = this->ReconstructedVolume;
@@ -256,9 +251,6 @@ vtkImageData* vtkIGSIOPasteSliceIntoVolume::GetReconstructedVolume()
 			LOG_WARNING(accOverflowCount << " voxels have had too many pixels inserted. This can result in errors in the final volume. It is recommended that the output volume resolution be increased.");
 		}
 	}
-
-	LOG_INFO("Reading OpenCL output");
-
 #endif
 
   return this->ReconstructedVolume;

--- a/Source/VolumeReconstruction/vtkIGSIOPasteSliceIntoVolumeHelperOpenCL.h
+++ b/Source/VolumeReconstruction/vtkIGSIOPasteSliceIntoVolumeHelperOpenCL.h
@@ -134,6 +134,7 @@ public:
 	cl::CommandQueue Queue;
 
 	vtkOpenCLContextParameters Parameters;
+	bool OutputVolumeChanged;
 };
 
 vtkOpenCLContext::vtkOpenCLContext(vtkOpenCLContextParameters parameters) : Parameters(parameters)
@@ -317,6 +318,8 @@ vtkOpenCLContext::vtkOpenCLContext(vtkOpenCLContextParameters parameters) : Para
 	}
 
 	this->Queue = cl::CommandQueue(this->Context, this->Device);
+
+	this->OutputVolumeChanged = false;
 }
 
 vtkOpenCLContext::~vtkOpenCLContext()
@@ -612,6 +615,8 @@ static void vtkOpenCLInsertSlice(vtkIGSIOPasteSliceIntoVolumeInsertSliceParams* 
 	  LOG_ERROR("Launch OpenCL kernel: " << err);
   }
 
+  context->OutputVolumeChanged = true;
+
   if (insertionParams->isLast) {
 	  vtkOpenCLReadOutput(insertionParams, context);
   }
@@ -628,7 +633,7 @@ static void vtkOpenCLInsertSlice(vtkIGSIOPasteSliceIntoVolumeInsertSliceParams* 
 
 static void vtkOpenCLReadOutput(vtkIGSIOPasteSliceIntoVolumeInsertSliceParams* insertionParams, vtkOpenCLContext *context)
 {
-	if (context == NULL)
+	if (context == NULL || !context->OutputVolumeChanged )
 	{
 		return;
 	}
@@ -695,6 +700,8 @@ static void vtkOpenCLReadOutput(vtkIGSIOPasteSliceIntoVolumeInsertSliceParams* i
 	if (err != CL_SUCCESS) {
 		LOG_ERROR("Finish OpenCL queue: " << err);
 	}
+
+	context->OutputVolumeChanged = false;
 }
 
 #endif


### PR DESCRIPTION
Copies the contents of the output OpenCL buffer to the CPU memory when `GetReconstructedVolume` is called. 

There are two notes I wish to add that may reflect how the change is merged:
* The Acculumation buffer is copied in addition to the Output volume. This can be changed in `vtkIGSIOPasteSliceIntoVolume.cxx`, lines 245 and 250, by setting the parameters to `NULL` instead. 
* In addition to being updated when `GetReconstructedVolume` is called, the output is also updated when the last slice is inserted. If this is no longer required, you can remove the call in `vtkIGSIOPasteSliceIntoVolumeHelperOpenCL.h` line 621, or drop the `IsLast` parameter altogether. 