### PR TITLE
ENH: add support for not writing pixel data

### DIFF
--- a/Source/SequenceIO/vtkIGSIOMetaImageSequenceIO.cxx
+++ b/Source/SequenceIO/vtkIGSIOMetaImageSequenceIO.cxx
@@ -622,15 +622,15 @@ igsioStatus vtkIGSIOMetaImageSequenceIO::WriteInitialImageHeader()
   }
 
   FrameSizeType frameSize = {0, 0, 0};
-  if (this->EnableImageDataWrite)
-  {
-    frameSize = this->GetMaximumImageDimensions();
-  }
-  else
+  if (this->ReduceImageDataToOnePixel)
   {
     frameSize[0] = 1;
     frameSize[1] = 1;
     frameSize[2] = 1;
+  }
+  else
+  {
+    frameSize = this->GetMaximumImageDimensions();
   }
 
   // Set the dimensions of the data to be written
@@ -639,7 +639,7 @@ igsioStatus vtkIGSIOMetaImageSequenceIO::WriteInitialImageHeader()
   this->Dimensions[2] = frameSize[2];
   this->Dimensions[3] = this->TrackedFrameList->GetNumberOfTrackedFrames();
 
-  if (this->EnableImageDataWrite)
+  if (!this->ReduceImageDataToOnePixel)
   {
     // Make sure the frame size is the same for each valid image
     // If it's needed, we can use the largest frame size for each frame and copy the image data row by row
@@ -675,7 +675,7 @@ igsioStatus vtkIGSIOMetaImageSequenceIO::WriteInitialImageHeader()
   this->SetFrameField("ElementType", pixelTypeStr);   // pixel type (a.k.a component type) is stored in the ElementType element
 
   // ElementNumberOfChannels
-  if (this->EnableImageDataWrite)
+  if (!this->ReduceImageDataToOnePixel)
   {
     if (this->TrackedFrameList->IsContainingValidImageData())
     {
@@ -686,14 +686,14 @@ igsioStatus vtkIGSIOMetaImageSequenceIO::WriteInitialImageHeader()
 
   this->SetFrameField(SEQMETA_FIELD_US_IMG_ORIENT, igsioCommon::GetStringFromUsImageOrientation(US_IMG_ORIENT_MF));
   // Image orientation
-  if (this->EnableImageDataWrite)
+  if (!this->ReduceImageDataToOnePixel)
   {
     std::string orientationStr = igsioCommon::GetStringFromUsImageOrientation(this->ImageOrientationInFile);
     this->SetFrameField(SEQMETA_FIELD_US_IMG_ORIENT, orientationStr);
   }
 
   // Image type
-  if (this->EnableImageDataWrite)
+  if (!this->ReduceImageDataToOnePixel)
   {
     std::string typeStr = igsioCommon::GetStringFromUsImageType(this->ImageType);
     this->SetFrameField(SEQMETA_FIELD_US_IMG_TYPE, typeStr);
@@ -887,7 +887,7 @@ igsioStatus vtkIGSIOMetaImageSequenceIO::AppendImagesToHeader()
       TotalBytesWritten += field.length();
     }
     //Only write this field if the image is saved. If only the tracking pose is kept do not save this field to the header
-    if (this->EnableImageDataWrite)
+    if (!this->ReduceImageDataToOnePixel)
     {
       // Add image status field
       std::string imageStatus("OK");
@@ -973,7 +973,7 @@ igsioStatus vtkIGSIOMetaImageSequenceIO::WriteCompressedImagePixelsToFile(int& c
   {
     igsioTrackedFrame* trackedFrame(NULL);
 
-    if (this->EnableImageDataWrite)
+    if (!this->ReduceImageDataToOnePixel)
     {
       trackedFrame = this->TrackedFrameList->GetTrackedFrame(frameNumber);
       if (trackedFrame == NULL)
@@ -985,7 +985,7 @@ igsioStatus vtkIGSIOMetaImageSequenceIO::WriteCompressedImagePixelsToFile(int& c
     }
 
     igsioVideoFrame* videoFrame = &blankFrame;
-    if (this->EnableImageDataWrite)
+    if (!this->ReduceImageDataToOnePixel)
     {
       if (trackedFrame->GetImageData()->IsImageValid())
       {
@@ -1318,20 +1318,23 @@ const char* vtkIGSIOMetaImageSequenceIO::GetDimensionKindsString()
 //----------------------------------------------------------------------------
 igsioStatus vtkIGSIOMetaImageSequenceIO::Close()
 {
-  // Update fields that are known only at the end of the processing
-  if (this->GetUseCompression())
+  if (!this->WriteHeaderOnly)
   {
-    std::stringstream ss;
-    ss << this->CompressedBytesWritten;
-    this->SetFrameField(SEQMETA_FIELD_COMPRESSED_DATA_SIZE, ss.str());
-    if (UpdateFieldInImageHeader(SEQMETA_FIELD_COMPRESSED_DATA_SIZE) != IGSIO_SUCCESS)
+    // Update fields that are known only at the end of the processing
+    if (this->GetUseCompression())
     {
-      return IGSIO_FAIL;
+      std::stringstream ss;
+      ss << this->CompressedBytesWritten;
+      this->SetFrameField(SEQMETA_FIELD_COMPRESSED_DATA_SIZE, ss.str());
+      if (UpdateFieldInImageHeader(SEQMETA_FIELD_COMPRESSED_DATA_SIZE) != IGSIO_SUCCESS)
+      {
+        return IGSIO_FAIL;
+      }
+      deflateEnd(&this->CompressionStream);   // clean up
     }
-    deflateEnd(&this->CompressionStream);   // clean up
-  }
 
-  fclose(this->OutputImageFileHandle);
+    fclose(this->OutputImageFileHandle);
+  }
 
   return Superclass::Close();
 }
@@ -1394,7 +1397,7 @@ igsioStatus vtkIGSIOMetaImageSequenceIO::SetFileName(const std::string& aFilenam
 //----------------------------------------------------------------------------
 igsioStatus vtkIGSIOMetaImageSequenceIO::UpdateDimensionsCustomStrings(int numberOfFrames, bool isData3D)
 {
-  if (this->EnableImageDataWrite && this->TrackedFrameList->IsContainingValidImageData())
+  if (!this->ReduceImageDataToOnePixel && this->TrackedFrameList->IsContainingValidImageData())
   {
     this->NumberOfScalarComponents = this->TrackedFrameList->GetNumberOfScalarComponents();
   }

--- a/Source/SequenceIO/vtkIGSIOMkvSequenceIO.cxx
+++ b/Source/SequenceIO/vtkIGSIOMkvSequenceIO.cxx
@@ -460,7 +460,7 @@ igsioStatus vtkIGSIOMkvSequenceIO::WriteImages()
     igsioTrackedFrame* trackedFrame(NULL);
     igsioVideoFrame* videoFrame(NULL);
 
-    if (this->EnableImageDataWrite)
+    if (!this->ReduceImageDataToOnePixel)
     {
       trackedFrame = this->TrackedFrameList->GetTrackedFrame(frameNumber);
       if (!trackedFrame)

--- a/Source/SequenceIO/vtkIGSIOMkvSequenceIO.h
+++ b/Source/SequenceIO/vtkIGSIOMkvSequenceIO.h
@@ -53,13 +53,18 @@ public:
   static bool CanWriteFile(const std::string& filename);
 
   /*! Update a field in the image header with its current value */
-  virtual igsioStatus UpdateFieldInImageHeader(const char* fieldName) VTK_OVERRIDE { return IGSIO_SUCCESS; } 
+  virtual igsioStatus UpdateFieldInImageHeader(const char* fieldName) VTK_OVERRIDE { return IGSIO_SUCCESS; }
 
   /*! Return the string that represents the dimensional sizes */
   virtual const char* GetDimensionSizeString() VTK_OVERRIDE { return ""; }
 
   /*! Return the string that represents the dimensional kinds */
   virtual const char* GetDimensionKindsString() VTK_OVERRIDE { return ""; }
+
+  virtual void SetWriteHeaderOnly(bool) VTK_OVERRIDE
+  {
+    LOG_WARNING(this->GetNameOfClass() << " does not support writing only the header");
+  }
 
   /*!
     Set input/output file name. The file contains only the image header in case of
@@ -103,4 +108,4 @@ protected:
   vtkInternal* Internal;
 };
 
-#endif // __vtkIGSIOMkvSequenceIO_h 
+#endif // __vtkIGSIOMkvSequenceIO_h

--- a/Source/SequenceIO/vtkIGSIOSequenceIO.cxx
+++ b/Source/SequenceIO/vtkIGSIOSequenceIO.cxx
@@ -17,7 +17,7 @@
 #endif
 
 //----------------------------------------------------------------------------
-igsioStatus vtkIGSIOSequenceIO::Write(const std::string& filename, const std::string& path, vtkIGSIOTrackedFrameList* frameList, US_IMAGE_ORIENTATION orientationInFile/*=US_IMG_ORIENT_MF*/, bool useCompression/*=true*/, bool enableImageDataWrite/*=true*/)
+igsioStatus vtkIGSIOSequenceIO::Write(const std::string& filename, const std::string& path, vtkIGSIOTrackedFrameList* frameList, US_IMAGE_ORIENTATION orientationInFile/*=US_IMG_ORIENT_MF*/, bool useCompression/*=true*/, bool reduceImageDataToOnePixel/*=false*/, bool writeHeaderOnly/*= false*/)
 {
 
   // Convert local filename to plus output filename
@@ -43,7 +43,8 @@ igsioStatus vtkIGSIOSequenceIO::Write(const std::string& filename, const std::st
     writer->SetOutputFilePath(outputPath);
     writer->SetImageOrientationInFile(orientationInFile);
     writer->SetTrackedFrameList(frameList);
-    writer->SetEnableImageDataWrite(enableImageDataWrite);
+    writer->SetReduceImageDataToOnePixel(reduceImageDataToOnePixel);
+    writer->SetWriteHeaderOnly(writeHeaderOnly);
     if (frameList->GetNumberOfTrackedFrames() == 1)
     {
       writer->IsDataTimeSeriesOff();
@@ -63,7 +64,8 @@ igsioStatus vtkIGSIOSequenceIO::Write(const std::string& filename, const std::st
     writer->SetOutputFilePath(outputPath);
     writer->SetImageOrientationInFile(orientationInFile);
     writer->SetTrackedFrameList(frameList);
-    writer->SetEnableImageDataWrite(enableImageDataWrite);
+    writer->SetReduceImageDataToOnePixel(reduceImageDataToOnePixel);
+    writer->SetWriteHeaderOnly(writeHeaderOnly);
     if (frameList->GetNumberOfTrackedFrames() == 1)
     {
       writer->IsDataTimeSeriesOff();
@@ -84,7 +86,8 @@ igsioStatus vtkIGSIOSequenceIO::Write(const std::string& filename, const std::st
     writer->SetOutputFilePath(outputPath);
     writer->SetImageOrientationInFile(orientationInFile);
     writer->SetTrackedFrameList(frameList);
-    writer->SetEnableImageDataWrite(enableImageDataWrite);
+    writer->SetReduceImageDataToOnePixel(reduceImageDataToOnePixel);
+    writer->SetWriteHeaderOnly(writeHeaderOnly);
     if (frameList->GetNumberOfTrackedFrames() == 1)
     {
       writer->IsDataTimeSeriesOff();
@@ -103,23 +106,23 @@ igsioStatus vtkIGSIOSequenceIO::Write(const std::string& filename, const std::st
 }
 
 //----------------------------------------------------------------------------
-igsioStatus vtkIGSIOSequenceIO::Write(const std::string& filename, const std::string& path, igsioTrackedFrame* frame, US_IMAGE_ORIENTATION orientationInFile /*= US_IMG_ORIENT_MF*/, bool useCompression /*= true*/, bool enableImageDataWrite /*= true*/)
+igsioStatus vtkIGSIOSequenceIO::Write(const std::string& filename, const std::string& path, igsioTrackedFrame* frame, US_IMAGE_ORIENTATION orientationInFile /*= US_IMG_ORIENT_MF*/, bool useCompression /*= true*/, bool reduceImageDataToOnePixel/*=false*/, bool writeHeaderOnly/*= false*/)
 {
   vtkNew<vtkIGSIOTrackedFrameList> list;
   list->AddTrackedFrame(frame);
-  return vtkIGSIOSequenceIO::Write(filename, path, list.GetPointer(), orientationInFile, useCompression, enableImageDataWrite);
+  return vtkIGSIOSequenceIO::Write(filename, path, list.GetPointer(), orientationInFile, useCompression, reduceImageDataToOnePixel, writeHeaderOnly);
 }
 
 //----------------------------------------------------------------------------
-igsioStatus vtkIGSIOSequenceIO::Write(const std::string& filename, igsioTrackedFrame* frame, US_IMAGE_ORIENTATION orientationInFile /*= US_IMG_ORIENT_MF*/, bool useCompression /*= true*/, bool enableImageDataWrite /*= true*/)
+igsioStatus vtkIGSIOSequenceIO::Write(const std::string& filename, igsioTrackedFrame* frame, US_IMAGE_ORIENTATION orientationInFile /*= US_IMG_ORIENT_MF*/, bool useCompression /*= true*/, bool reduceImageDataToOnePixel/*=false*/, bool writeHeaderOnly/*= false*/)
 {
-  return vtkIGSIOSequenceIO::Write(vtksys::SystemTools::GetFilenameName(filename), vtksys::SystemTools::GetFilenamePath(filename), frame, orientationInFile, useCompression, enableImageDataWrite);
+  return vtkIGSIOSequenceIO::Write(vtksys::SystemTools::GetFilenameName(filename), vtksys::SystemTools::GetFilenamePath(filename), frame, orientationInFile, useCompression, reduceImageDataToOnePixel, writeHeaderOnly);
 }
 
 //----------------------------------------------------------------------------
-igsioStatus vtkIGSIOSequenceIO::Write(const std::string& filename, vtkIGSIOTrackedFrameList* frameList, US_IMAGE_ORIENTATION orientationInFile /*= US_IMG_ORIENT_MF*/, bool useCompression /*= true*/, bool enableImageDataWrite /*= true*/)
+igsioStatus vtkIGSIOSequenceIO::Write(const std::string& filename, vtkIGSIOTrackedFrameList* frameList, US_IMAGE_ORIENTATION orientationInFile /*= US_IMG_ORIENT_MF*/, bool useCompression /*= true*/, bool reduceImageDataToOnePixel/*=false*/, bool writeHeaderOnly/*= false*/)
 {
-  return vtkIGSIOSequenceIO::Write(vtksys::SystemTools::GetFilenameName(filename), vtksys::SystemTools::GetFilenamePath(filename), frameList, orientationInFile, useCompression, enableImageDataWrite);
+  return vtkIGSIOSequenceIO::Write(vtksys::SystemTools::GetFilenameName(filename), vtksys::SystemTools::GetFilenamePath(filename), frameList, orientationInFile, useCompression, reduceImageDataToOnePixel, writeHeaderOnly);
 }
 
 //----------------------------------------------------------------------------

--- a/Source/SequenceIO/vtkIGSIOSequenceIO.h
+++ b/Source/SequenceIO/vtkIGSIOSequenceIO.h
@@ -23,12 +23,12 @@ class VTKSEQUENCEIO_EXPORT vtkIGSIOSequenceIO : public vtkObject
 {
 public:
   /*! Write object contents into file */
-  static igsioStatus Write(const std::string& filename, const std::string& path, igsioTrackedFrame* frame, US_IMAGE_ORIENTATION orientationInFile = US_IMG_ORIENT_MF, bool useCompression = true, bool enableImageDataWrite = true);
-  static igsioStatus Write(const std::string& filename, igsioTrackedFrame* frame, US_IMAGE_ORIENTATION orientationInFile = US_IMG_ORIENT_MF, bool useCompression = true, bool enableImageDataWrite = true);
+  static igsioStatus Write(const std::string& filename, const std::string& path, igsioTrackedFrame* frame, US_IMAGE_ORIENTATION orientationInFile = US_IMG_ORIENT_MF, bool useCompression = true, bool reduceImageDataToOnePixel = false, bool writeHeaderOnly = false);
+  static igsioStatus Write(const std::string& filename, igsioTrackedFrame* frame, US_IMAGE_ORIENTATION orientationInFile = US_IMG_ORIENT_MF, bool useCompression = true, bool reduceImageDataToOnePixel = false, bool writeHeaderOnly = false);
 
   /*! Write object contents into file */
-  static igsioStatus Write(const std::string& filename, const std::string& path, vtkIGSIOTrackedFrameList* frameList, US_IMAGE_ORIENTATION orientationInFile = US_IMG_ORIENT_MF, bool useCompression = true, bool enableImageDataWrite = true);
-  static igsioStatus Write(const std::string& filename, vtkIGSIOTrackedFrameList* frameList, US_IMAGE_ORIENTATION orientationInFile = US_IMG_ORIENT_MF, bool useCompression = true, bool enableImageDataWrite = true);
+  static igsioStatus Write(const std::string& filename, const std::string& path, vtkIGSIOTrackedFrameList* frameList, US_IMAGE_ORIENTATION orientationInFile = US_IMG_ORIENT_MF, bool useCompression = true, bool reduceImageDataToOnePixel = false, bool writeHeaderOnly = false);
+  static igsioStatus Write(const std::string& filename, vtkIGSIOTrackedFrameList* frameList, US_IMAGE_ORIENTATION orientationInFile = US_IMG_ORIENT_MF, bool useCompression = true, bool reduceImageDataToOnePixel = false, bool writeHeaderOnly = false);
 
   /*! Read file contents into the object */
   static igsioStatus Read(const std::string& filename, vtkIGSIOTrackedFrameList* frameList);

--- a/Source/SequenceIO/vtkIGSIOSequenceIOBase.cxx
+++ b/Source/SequenceIO/vtkIGSIOSequenceIOBase.cxx
@@ -28,7 +28,6 @@ vtkIGSIOSequenceIOBase::vtkIGSIOSequenceIOBase()
   : TrackedFrameList(vtkIGSIOTrackedFrameList::New())
   , UseCompression(false)
   , CompressedBytesWritten(0)
-  , EnableImageDataWrite(true)
   , PixelType(VTK_VOID)
   , NumberOfScalarComponents(1)
   , IsDataTimeSeries(true)
@@ -194,7 +193,7 @@ const char* vtkIGSIOSequenceIOBase::GetCustomString(const char* fieldName)
     return NULL;
   }
   // Can't return this->GetFrameField(fieldName).c_str(), since the string object would be deleted,
-  // leaving a dangling char* pointer. 
+  // leaving a dangling char* pointer.
   return this->TrackedFrameList->GetCustomString(fieldName);
 }
 
@@ -228,7 +227,7 @@ void vtkIGSIOSequenceIOBase::CreateTrackedFrameIfNonExisting(unsigned int frameN
 //----------------------------------------------------------------------------
 igsioStatus vtkIGSIOSequenceIOBase::PrepareHeader()
 {
-  if (this->EnableImageDataWrite && this->TrackedFrameList->IsContainingValidImageData())
+  if (!this->ReduceImageDataToOnePixel && this->TrackedFrameList->IsContainingValidImageData())
   {
     if (this->ImageOrientationInFile == US_IMG_ORIENT_XX)
     {
@@ -282,6 +281,10 @@ igsioStatus vtkIGSIOSequenceIOBase::PrepareHeader()
     return IGSIO_FAIL;
   }
 
+  if (this->WriteHeaderOnly)
+  {
+    return IGSIO_SUCCESS;
+  }
   return this->PrepareImageFile();
 }
 
@@ -310,9 +313,12 @@ igsioStatus vtkIGSIOSequenceIOBase::Write()
     return IGSIO_FAIL;
   }
 
-  if (this->WriteImages() != IGSIO_SUCCESS)
+  if (!this->WriteHeaderOnly)
   {
-    return IGSIO_FAIL;
+    if (this->WriteImages() != IGSIO_SUCCESS)
+    {
+      return IGSIO_FAIL;
+    }
   }
 
   this->Close();
@@ -330,24 +336,27 @@ igsioStatus vtkIGSIOSequenceIOBase::Close()
 
   LOG_DEBUG("Moved file from: " << this->TempHeaderFileName << " to " << headerFullPath);
 
-  if (this->PixelDataFileName.empty())
+  if (!this->WriteHeaderOnly)
   {
-    // Append image to final file (single file)
-    AppendFile(this->TempImageFileName, headerFullPath.c_str());
-  }
-  else
-  {
-    // Rename image to final filename (header+data file)
+    if (this->PixelDataFileName.empty())
+    {
+      // Append image to final file (single file)
+      AppendFile(this->TempImageFileName, headerFullPath.c_str());
+    }
+    else
+    {
+      // Rename image to final filename (header+data file)
 
-    // Use the same path as the header but replace the filename
-    std::vector<std::string> pathElements;
-    vtksys::SystemTools::SplitPath(headerFullPath.c_str(), pathElements);
-    pathElements.erase(pathElements.end() - 1);
-    std::string pixelDataFileNameOnly = vtksys::SystemTools::GetFilenameName(this->PixelDataFileName);
-    pathElements.push_back(pixelDataFileNameOnly);
-    std::string pixFullPath = vtksys::SystemTools::JoinPath(pathElements);
+      // Use the same path as the header but replace the filename
+      std::vector<std::string> pathElements;
+      vtksys::SystemTools::SplitPath(headerFullPath.c_str(), pathElements);
+      pathElements.erase(pathElements.end() - 1);
+      std::string pixelDataFileNameOnly = vtksys::SystemTools::GetFilenameName(this->PixelDataFileName);
+      pathElements.push_back(pixelDataFileNameOnly);
+      std::string pixFullPath = vtksys::SystemTools::JoinPath(pathElements);
 
-    MoveFileInternal(this->TempImageFileName.c_str(), pixFullPath.c_str());
+      MoveFileInternal(this->TempImageFileName.c_str(), pixFullPath.c_str());
+    }
   }
 
   this->TempHeaderFileName.clear();
@@ -363,7 +372,7 @@ igsioStatus vtkIGSIOSequenceIOBase::Close()
 //----------------------------------------------------------------------------
 igsioStatus vtkIGSIOSequenceIOBase::WriteImages()
 {
-  if (this->EnableImageDataWrite && this->TrackedFrameList->IsContainingValidImageData() && this->ImageOrientationInFile != this->TrackedFrameList->GetImageOrientation())
+  if (!this->ReduceImageDataToOnePixel && this->TrackedFrameList->IsContainingValidImageData() && this->ImageOrientationInFile != this->TrackedFrameList->GetImageOrientation())
   {
     // Reordering of the frames is not implemented, so return with an error
     LOG_ERROR("Saving of images is supported only in the same orientation as currently in the memory");
@@ -379,54 +388,57 @@ igsioStatus vtkIGSIOSequenceIOBase::WriteImages()
   }
 
   igsioStatus result = IGSIO_SUCCESS;
-  if (!GetUseCompression())
+  if (!this->WriteHeaderOnly)
   {
-    if (imageDataAvailable)
+    if (!GetUseCompression())
     {
-      // Create a blank frame if we have to write an invalid frame to sequence file
-      igsioVideoFrame blankFrame;
-      FrameSizeType frameSize = { this->Dimensions[0], this->Dimensions[1], this->Dimensions[2] };
-      if (blankFrame.AllocateFrame(frameSize, this->PixelType, this->NumberOfScalarComponents) != IGSIO_SUCCESS)
+      if (imageDataAvailable)
       {
-        LOG_ERROR("Failed to allocate space for blank image.");
-        return IGSIO_FAIL;
-      }
-      blankFrame.FillBlank();
-
-      // not compressed
-      for (unsigned int frameNumber = 0; frameNumber < this->TrackedFrameList->GetNumberOfTrackedFrames(); frameNumber++)
-      {
-        igsioTrackedFrame* trackedFrame = this->TrackedFrameList->GetTrackedFrame(frameNumber);
-
-        igsioVideoFrame* videoFrame = &blankFrame;
-        if (this->EnableImageDataWrite && trackedFrame->GetImageData()->IsImageValid())
+        // Create a blank frame if we have to write an invalid frame to sequence file
+        igsioVideoFrame blankFrame;
+        FrameSizeType frameSize = { this->Dimensions[0], this->Dimensions[1], this->Dimensions[2] };
+        if (blankFrame.AllocateFrame(frameSize, this->PixelType, this->NumberOfScalarComponents) != IGSIO_SUCCESS)
         {
-          videoFrame = trackedFrame->GetImageData();
+          LOG_ERROR("Failed to allocate space for blank image.");
+          return IGSIO_FAIL;
         }
+        blankFrame.FillBlank();
 
-        size_t writtenSize = 0;
-        igsioStatus status = igsioCommon::RobustFwrite(this->OutputImageFileHandle, videoFrame->GetScalarPointer(),
-          videoFrame->GetFrameSizeInBytes(), writtenSize);
-        if (status == IGSIO_FAIL)
+        // not compressed
+        for (unsigned int frameNumber = 0; frameNumber < this->TrackedFrameList->GetNumberOfTrackedFrames(); frameNumber++)
         {
-          LOG_ERROR("Unable to write entire frame to file. Frame size: " << videoFrame->GetFrameSizeInBytes()
-            << ", successfully written: " << writtenSize << " bytes");
+          igsioTrackedFrame* trackedFrame = this->TrackedFrameList->GetTrackedFrame(frameNumber);
+
+          igsioVideoFrame* videoFrame = &blankFrame;
+          if (!this->ReduceImageDataToOnePixel && trackedFrame->GetImageData()->IsImageValid())
+          {
+            videoFrame = trackedFrame->GetImageData();
+          }
+
+          size_t writtenSize = 0;
+          igsioStatus status = igsioCommon::RobustFwrite(this->OutputImageFileHandle, videoFrame->GetScalarPointer(),
+            videoFrame->GetFrameSizeInBytes(), writtenSize);
+          if (status == IGSIO_FAIL)
+          {
+            LOG_ERROR("Unable to write entire frame to file. Frame size: " << videoFrame->GetFrameSizeInBytes()
+              << ", successfully written: " << writtenSize << " bytes");
+          }
+          this->TotalBytesWritten += writtenSize;
         }
-        this->TotalBytesWritten += writtenSize;
       }
     }
-  }
-  else
-  {
-    // compressed
-    int compressedDataSize = 0;
-    if (imageDataAvailable)
+    else
     {
-      result = WriteCompressedImagePixelsToFile(compressedDataSize);
-      if (result == IGSIO_SUCCESS)
+      // compressed
+      int compressedDataSize = 0;
+      if (imageDataAvailable)
       {
-        TotalBytesWritten += compressedDataSize;
-        this->CompressedBytesWritten += compressedDataSize;
+        result = WriteCompressedImagePixelsToFile(compressedDataSize);
+        if (result == IGSIO_SUCCESS)
+        {
+          TotalBytesWritten += compressedDataSize;
+          this->CompressedBytesWritten += compressedDataSize;
+        }
       }
     }
   }

--- a/Source/SequenceIO/vtkIGSIOSequenceIOBase.h
+++ b/Source/SequenceIO/vtkIGSIOSequenceIOBase.h
@@ -135,12 +135,19 @@ public:
   /*! Return the dimensions of the sequence */
   std::array<unsigned int, 4> GetDimensions() const;
 
+  /*! Flag to write small token data instead of real pixel data */
+  vtkGetMacro(ReduceImageDataToOnePixel, bool);
+  /*! Flag write small token data instead of real pixel data */
+  vtkSetMacro(ReduceImageDataToOnePixel, bool);
+  /*! Flag write small token data instead of real pixel data */
+  vtkBooleanMacro(ReduceImageDataToOnePixel, bool);
+
   /*! Flag to enable/disable writing of image data */
-  vtkGetMacro(EnableImageDataWrite, bool);
+  vtkGetMacro(WriteHeaderOnly, bool);
   /*! Flag to enable/disable writing of image data */
-  vtkSetMacro(EnableImageDataWrite, bool);
+  vtkSetMacro(WriteHeaderOnly, bool);
   /*! Flag to enable/disable writing of image data */
-  vtkBooleanMacro(EnableImageDataWrite, bool);
+  vtkBooleanMacro(WriteHeaderOnly, bool);
 
 protected:
   /*! Read all the fields in the image file header */
@@ -227,7 +234,9 @@ protected:
   /*! Buffered compressed data size */
   unsigned long long CompressedBytesWritten;
   /*! Whether to enable pixel writing */
-  bool EnableImageDataWrite;
+  bool WriteHeaderOnly = false;
+  /*! Whether to write small token data instead of real pixel data */
+  bool ReduceImageDataToOnePixel = true;
   /*! Integer/float, short/long, signed/unsigned */
   igsioCommon::VTKScalarPixelType PixelType;
   /*! Number of components (or channels) */


### PR DESCRIPTION
This facilitates updating the header file in header + data file scenario.

This breaks backwards compatibility because ivar `EnableImageDataWrite` was renamed into `DoNotAlterPixelData`. Rename was done due to it being misleading. It doesn't just enables/disables writing of image data, it modifies image data to have minimal size in order to produce a valid file. New ivar `WriteHeaderOnly` truly disables writing image data file.