### PR TITLE
COMP: Fix failed checkout of vtkaddon

### DIFF
--- a/SuperBuild/External_vtkAddon.cmake
+++ b/SuperBuild/External_vtkAddon.cmake
@@ -29,12 +29,12 @@ ELSE()
       /DWIN32
       )
   ENDIF()
-  
+
   IF(NOT DEFINED(vtkAddon_GIT_REPOSITORY))
     SET(vtkAddon_GIT_REPOSITORY "https://github.com/Slicer/vtkAddon.git" CACHE STRING "Set vtkAddon desired git url")
   ENDIF()
   IF(NOT DEFINED(vtkAddon_GIT_REVISION))
-    SET(vtkAddon_GIT_REVISION "master" CACHE STRING "Set vtkAddon desired git hash (master means latest)")
+    SET(vtkAddon_GIT_REVISION "main" CACHE STRING "Set vtkAddon desired git hash (main means latest)")
   ENDIF()
 
   ExternalProject_Add(vtkAddon


### PR DESCRIPTION
This fixes the following CMake Error:

> CMake Error at vtkAddon-prefix/tmp/vtkAddon-gitclone.cmake:49 (message):
>   Failed to checkout tag: 'master'

https://github.com/Slicer/vtkAddon has recently renamed their default branch from `master` to `main`.