### PR TITLE
BUG: Reconstructed volume extent shifted away from true frame positions

### DIFF
--- a/VolumeReconstruction/vtkIGSIOVolumeReconstructor.cxx
+++ b/VolumeReconstruction/vtkIGSIOVolumeReconstructor.cxx
@@ -430,14 +430,11 @@ igsioStatus vtkIGSIOVolumeReconstructor::SetOutputExtentFromFrameList(vtkIGSIOTr
     return IGSIO_FAIL;
   }
 
-  // Adjust the output origin  so it falls on a multiple of voxel spacing.
-  // This ensures the same voxel lattice when multiple sweeps are volume-reconstructed independently.
-  // If the multi-sweep volume reconstructions are later merged, no resampling will be necessary.
   double* outputSpacing = this->Reconstructor->GetOutputSpacing();
   double outputOrigin_Ref[3] = { 0.0, 0.0, 0.0 };
   for (int d = 0; d < 3; d++)
   {
-    outputOrigin_Ref[d] = std::floor(extent_Ref[d * 2] / outputSpacing[d]) * outputSpacing[d];
+    outputOrigin_Ref[d] = extent_Ref[d * 2];
   }
 
   // Set the output extent from the current min and max values, using the user-defined image resolution.


### PR DESCRIPTION
We have a use case where for certain individual volumes, we collect a small number of frames with a large output spacing. In this case, due to the low frame count, the behavior of adjusting the output origin to fall on a multiple of the defined spacing on volume reconstruction is noticeable - that behavior affects the output extent such that there can be "holes" at the beginning or end of the frame sequence that get filled when hole filling is turned on, creating phantom data which isn't present in the unreconstructed data. The pasted slices also don't reflect the true encoder locations of the unreconstructed data.

Here is a coronal view of a volume which had 5 unique z positions in the original data. Left is with these changes, right is using the main branch. 
![image](https://github.com/IGSIO/IGSIO/assets/3487395/a0da0b7e-3c68-46cc-bedd-92401383979d)

@Sunderlandkyl any thoughts here since you added https://github.com/PlusToolkit/PlusLib/commit/16ea8438dae09abd28e440045ee4f04080810aad ? Also wasn't sure about what the multi-sweep volume reconstruction is referring to in the comment. Could these changes be wrapped in a flag passed to `SetOutputExtentFromFrameList`, and also propagated to a flag in https://github.com/PlusToolkit/PlusLib/blob/951a51b1252a5dc0b904bc2f7f6b48536d5db026/src/PlusVolumeReconstruction/Tools/VolumeReconstructor.cxx#L179 ?