### PR TITLE
BUG: Fix incorrect output extent of volume reconstructor

### DIFF
--- a/VolumeReconstruction/vtkIGSIOVolumeReconstructor.h
+++ b/VolumeReconstruction/vtkIGSIOVolumeReconstructor.h
@@ -125,6 +125,10 @@ public:
   vtkGetMacro(EnableFanAnglesAutoDetect, bool);
   vtkSetMacro(EnableFanAnglesAutoDetect, bool);
 
+  /*! Get/set RecomputeOutputSpacing. If true, recompute output spacing so reconstruction grid matches data exactly. */
+  vtkGetMacro(RecomputeOutputSpacing, bool);
+  vtkSetMacro(RecomputeOutputSpacing, bool);
+
   /*!
     Get the clip rectangle origin to apply to the image in pixel coordinates.
   */
@@ -238,6 +242,9 @@ protected:
 
   /*! Automatically reduce the fan angle to only sector that has proper acoustic coupling */
   bool EnableFanAnglesAutoDetect;
+
+  /*! Recompute output spacing so reconstruction grid matches data exactly. */
+  bool RecomputeOutputSpacing;
 
   /*! only every [SkipInterval] images from the input will be used in the reconstruction (Ie this is the number of frames that are skipped when the index is increased) */
   int SkipInterval;


### PR DESCRIPTION
Change the output spacing slightly so the output extent contains all frames without exceeding the voxel lattice. The output extent can extend beyond existing data when using ceil, or not include some of the data when using floor, which produces holes in the image.

The frame spacing changed only by about 0.1% during my testing, but I expect it depends on the precision of the encoders.

This is a follow up to https://github.com/IGSIO/IGSIO/pull/38. Please let me know what you think @Sunderlandkyl , @dzenanz.