### PR TITLE
Add tests to pivot and spin calibration and fix a precision bug

### DIFF
--- a/IGSIOCalibration/CMakeLists.txt
+++ b/IGSIOCalibration/CMakeLists.txt
@@ -49,3 +49,7 @@ set(vcProj_vtk${PROJECT_NAME} vtk${PROJECT_NAME};${IGSIO_BINARY_DIR}/src/${PROJE
 # Install
 #
 IGSIOInstallLibrary(vtk${PROJECT_NAME} ${PROJECT_NAME})
+
+if(BUILD_TESTING)
+  add_subdirectory(Testing)
+endif()

--- a/IGSIOCalibration/Testing/CMakeLists.txt
+++ b/IGSIOCalibration/Testing/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_executable(vtkIGSIOPivotCalibrationTest vtkIGSIOPivotCalibrationTest.cxx Utils.h)
+target_link_libraries(vtkIGSIOPivotCalibrationTest vtkIGSIOCalibration vtkIGSIOCommon)
+
+add_executable(vtkIGSIOSpinCalibrationTest vtkIGSIOSpinCalibrationTest.cxx Utils.h)
+target_link_libraries(vtkIGSIOSpinCalibrationTest vtkIGSIOCalibration vtkIGSIOCommon)
+
+add_test(vtkIGSIOPivotCalibrationTest
+  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/vtkIGSIOPivotCalibrationTest
+)
+
+add_test(vtkIGSIOSpinCalibrationTest
+  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/vtkIGSIOSpinCalibrationTest
+)

--- a/IGSIOCalibration/Testing/Utils.h
+++ b/IGSIOCalibration/Testing/Utils.h
@@ -77,17 +77,17 @@ static vtkNew<vtkMatrix4x4> ApplyRandomPerturbation(vtkMatrix4x4* matrix, double
   return result;
 }
 
-static vtkNew<vtkMatrix4x4> RotateAroundAxisAtPoint(vtkMatrix4x4* markerToWorld, const vtkVector3d& axisWorld, const vtkVector3d& pointWorld, double angleDegrees)
+// Craetes a new matrix that applies the original matrix, then rotates its result around `axis` at `point` by `angleDegrees`.
+static vtkNew<vtkMatrix4x4> RotateAroundAxisAtPoint(vtkMatrix4x4* matrix, const vtkVector3d& axis, const vtkVector3d& point, double angleDegrees)
 {
   vtkNew<vtkTransform> transform;
 
-  // Translate to origin, rotate, translate back
-  transform->Translate(pointWorld[0], pointWorld[1], pointWorld[2]);
-  transform->RotateWXYZ(angleDegrees, axisWorld.GetData());
-  transform->Translate(-pointWorld[0], -pointWorld[1], -pointWorld[2]);
-
-  // Apply to markerToWorld
-  transform->Concatenate(markerToWorld);
+  // Apply the original matrix, translate to origin, rotate, then translate back
+  // Note that vtkTransform is PreMultiply by default, so the last transform is applied first
+  transform->Translate(point[0], point[1], point[2]);
+  transform->RotateWXYZ(angleDegrees, axis.GetData());
+  transform->Translate(-point[0], -point[1], -point[2]);
+  transform->Concatenate(matrix);
 
   vtkNew<vtkMatrix4x4> result;
   transform->GetMatrix(result);

--- a/IGSIOCalibration/Testing/Utils.h
+++ b/IGSIOCalibration/Testing/Utils.h
@@ -57,10 +57,10 @@ static vtkNew<vtkMatrix4x4> GenerateRandomRotationMatrix(std::mt19937& rng)
 }
 
 // Applies a small random rotation to a matrix to simulate tracking noise
-static vtkNew<vtkMatrix4x4> ApplyRandomPerturbation(vtkMatrix4x4* matrix, double angleSigma, double translationSigma, std::mt19937& rng)
+static vtkNew<vtkMatrix4x4> ApplyRandomPerturbation(vtkMatrix4x4* matrix, double maxAngle, double translationSigma, std::mt19937& rng)
 {
-  std::uniform_real_distribution<double> angleDist(0.0, angleSigma);
-  std::uniform_real_distribution<double> translationDist(0.0, translationSigma);
+  std::uniform_real_distribution<double> angleDist(0.0, maxAngle);
+  std::normal_distribution<double> translationDist(0.0, translationSigma);
 
   const vtkVector3d perturbAxis = GenerateRandomDirection(rng);
   const double perturbAngle = angleDist(rng);

--- a/IGSIOCalibration/Testing/Utils.h
+++ b/IGSIOCalibration/Testing/Utils.h
@@ -2,6 +2,7 @@
 #define __vtkIGSIOCalibrationTestingUtils
 
 #include <vtkVector.h>
+#include <vtkVectorOperators.h>
 #include <vtkMatrix4x4.h>
 #include <vtkTransform.h>
 #include <vtkMath.h>
@@ -56,17 +57,21 @@ static vtkNew<vtkMatrix4x4> GenerateRandomRotationMatrix(std::mt19937& rng)
 }
 
 // Applies a small random rotation to a matrix to simulate tracking noise
-static vtkNew<vtkMatrix4x4> ApplyRandomPerturbation(vtkMatrix4x4* matrix, double maxAngleDegrees, std::mt19937& rng)
+static vtkNew<vtkMatrix4x4> ApplyRandomPerturbation(vtkMatrix4x4* matrix, double angleSigma, double translationSigma, std::mt19937& rng)
 {
-  std::uniform_real_distribution<double> angleDist(0.0, maxAngleDegrees);
-  vtkVector3d perturbAxis = GenerateRandomDirection(rng);
-  double perturbAngle = angleDist(rng);
+  std::uniform_real_distribution<double> angleDist(0.0, angleSigma);
+  std::uniform_real_distribution<double> translationDist(0.0, translationSigma);
+
+  const vtkVector3d perturbAxis = GenerateRandomDirection(rng);
+  const double perturbAngle = angleDist(rng);
+  const vtkVector3d perturbTranslation = translationDist(rng) * GenerateRandomDirection(rng);
 
   vtkNew<vtkTransform> transform;
   vtkNew<vtkMatrix4x4> result;
 
   transform->SetMatrix(matrix);
   transform->RotateWXYZ(perturbAngle, perturbAxis.GetData());
+  transform->Translate(perturbTranslation.GetData());
   transform->GetMatrix(result);
 
   return result;

--- a/IGSIOCalibration/Testing/Utils.h
+++ b/IGSIOCalibration/Testing/Utils.h
@@ -1,0 +1,93 @@
+#ifndef __vtkIGSIOCalibrationTestingUtils
+#define __vtkIGSIOCalibrationTestingUtils
+
+#include <vtkVector.h>
+#include <vtkMatrix4x4.h>
+#include <vtkTransform.h>
+#include <vtkMath.h>
+
+#include <random>
+
+static vtkVector3d GenerateRandomDirection(std::mt19937& rng)
+{
+  std::uniform_real_distribution<double> distTheta(0.0, 2 * vtkMath::Pi());
+  std::uniform_real_distribution<double> distZ(-1.0, 1.0);
+
+  const double theta = distTheta(rng);
+  const double z = distZ(rng);
+  const double r = std::sqrt(1.0 - z * z);
+
+  return vtkVector3d(r * std::cos(theta), r * std::sin(theta), z);
+}
+
+static vtkVector3d GenerateRandomPerpendicularDirection(const vtkVector3d& dir, std::mt19937& rng)
+{
+  std::uniform_real_distribution<double> distAngle(0.0, 360.0);
+
+  const vtkVector3d arbitrary = (std::abs(dir[0]) < 0.9) ? vtkVector3d(1, 0, 0) : vtkVector3d(0, 1, 0);
+  const vtkVector3d perp = dir.Cross(arbitrary).Normalized();
+
+  // Rotate by random angle around dir to get a random perpendicular direction
+  const double angle = distAngle(rng);
+
+  vtkNew<vtkTransform> transform;
+  transform->RotateWXYZ(angle, dir.GetData());
+
+  double perpRotated[3];
+  transform->TransformPoint(perp.GetData(), perpRotated);
+
+  return vtkVector3d(perpRotated);
+}
+
+static vtkNew<vtkMatrix4x4> GenerateRandomRotationMatrix(std::mt19937& rng)
+{
+  std::uniform_real_distribution<double> distAngle(0.0, 360.0);
+
+  const vtkVector3d axis = GenerateRandomDirection(rng);
+  const double angleDegrees = distAngle(rng);
+
+  vtkNew<vtkTransform> transform;
+  transform->RotateWXYZ(angleDegrees, axis.GetData());
+
+  vtkNew<vtkMatrix4x4> rotation;
+  transform->GetMatrix(rotation);
+
+  return rotation;
+}
+
+// Applies a small random rotation to a matrix to simulate tracking noise
+static vtkNew<vtkMatrix4x4> ApplyRandomPerturbation(vtkMatrix4x4* matrix, double maxAngleDegrees, std::mt19937& rng)
+{
+  std::uniform_real_distribution<double> angleDist(0.0, maxAngleDegrees);
+  vtkVector3d perturbAxis = GenerateRandomDirection(rng);
+  double perturbAngle = angleDist(rng);
+
+  vtkNew<vtkTransform> transform;
+  vtkNew<vtkMatrix4x4> result;
+
+  transform->SetMatrix(matrix);
+  transform->RotateWXYZ(perturbAngle, perturbAxis.GetData());
+  transform->GetMatrix(result);
+
+  return result;
+}
+
+static vtkNew<vtkMatrix4x4> RotateAroundAxisAtPoint(vtkMatrix4x4* markerToWorld, const vtkVector3d& axisWorld, const vtkVector3d& pointWorld, double angleDegrees)
+{
+  vtkNew<vtkTransform> transform;
+
+  // Translate to origin, rotate, translate back
+  transform->Translate(pointWorld[0], pointWorld[1], pointWorld[2]);
+  transform->RotateWXYZ(angleDegrees, axisWorld.GetData());
+  transform->Translate(-pointWorld[0], -pointWorld[1], -pointWorld[2]);
+
+  // Apply to markerToWorld
+  transform->Concatenate(markerToWorld);
+
+  vtkNew<vtkMatrix4x4> result;
+  transform->GetMatrix(result);
+
+  return result;
+}
+
+#endif

--- a/IGSIOCalibration/Testing/vtkIGSIOPivotCalibrationTest.cxx
+++ b/IGSIOCalibration/Testing/vtkIGSIOPivotCalibrationTest.cxx
@@ -1,4 +1,5 @@
 #include "vtkIGSIOPivotCalibrationAlgo.h"
+#include "Utils.h"
 
 #include <vtkMath.h>
 #include <vtkMatrix4x4.h>
@@ -12,38 +13,11 @@
 
 struct GroundTruth
 {
-  vtkVector3d TipPositionWorld;  // Fixed pivot point in world coordinates
-  vtkVector3d TipPositionMarker; // Fixed pivot point in marker coordinates
-  vtkVector3d TipDir;            // The unit vector direction from the stylus marker to the tip in marker coordinates
-  double StylusLength;           // Length from tracker origin to tip
+  vtkVector3d TipPosition_World;  // Fixed pivot point in world coordinates
+  vtkVector3d TipPosition_Marker; // Fixed pivot point in marker coordinates
+  vtkVector3d TipDir_Marker;      // The unit vector direction from the stylus marker to the tip in marker coordinates
+  double StylusLength;            // Length from tracker origin to tip
 };
-
-static vtkVector3d GenerateRandomDirection(std::mt19937& rng)
-{
-  std::uniform_real_distribution<double> distTheta(0.0, 2 * vtkMath::Pi());
-  std::uniform_real_distribution<double> distZ(-1.0, 1.0);
-
-  const double theta = distTheta(rng);
-  const double z = distZ(rng);
-  const double r = std::sqrt(1.0 - z * z);
-
-  return vtkVector3d(r * std::cos(theta), r * std::sin(theta), z);
-}
-
-static vtkNew<vtkMatrix4x4> GenerateRandomRotationMatrix(std::mt19937& rng)
-{
-  vtkVector3d axis = GenerateRandomDirection(rng);
-  std::uniform_real_distribution<double> distAngle(0.0, 360.0);
-  double angleDegrees = distAngle(rng);
-
-  vtkNew<vtkTransform> transform;
-  transform->RotateWXYZ(angleDegrees, axis.GetData());
-
-  vtkNew<vtkMatrix4x4> rotation;
-  transform->GetMatrix(rotation);
-
-  return rotation;
-}
 
 static GroundTruth GenerateGroundTruth(double stylusLength, std::mt19937& rng)
 {
@@ -52,27 +26,26 @@ static GroundTruth GenerateGroundTruth(double stylusLength, std::mt19937& rng)
   const vtkVector3d dir = GenerateRandomDirection(rng);
 
   GroundTruth gt;
-  gt.TipPositionWorld = vtkVector3d(dist(rng), dist(rng), dist(rng));
-  gt.TipPositionMarker = stylusLength * dir;
-  gt.TipDir = dir;
+  gt.TipPosition_World = vtkVector3d(dist(rng), dist(rng), dist(rng));
+  gt.TipPosition_Marker = stylusLength * dir;
+  gt.TipDir_Marker = dir;
   gt.StylusLength = stylusLength;
   return gt;
 }
 
 // Generates a random MarkerToWorld transform: maps points in marker coordinates to world coordinates.
-// tipNoise is added to the tip position to simulate non-steady surface.
-static vtkNew<vtkMatrix4x4> GenerateRandomMarkerTransform(const GroundTruth& gt, const vtkVector3d& tipNoise, std::mt19937& rng)
+static vtkNew<vtkMatrix4x4> GenerateRandomMarkerTransform(const GroundTruth& gt, std::mt19937& rng)
 {
   vtkNew<vtkMatrix4x4> markerToWorld = GenerateRandomRotationMatrix(rng);
 
-  const vtkVector4d markerToTipDir(gt.TipDir[0], gt.TipDir[1], gt.TipDir[2], 0);
+  const vtkVector4d markerToTipDir(gt.TipDir_Marker[0], gt.TipDir_Marker[1], gt.TipDir_Marker[2], 0);
   double markerToTipDirWorldData[4];
 
   markerToWorld->MultiplyPoint(markerToTipDir.GetData(), markerToTipDirWorldData);
 
   const vtkVector3d markerToTipWorld(markerToTipDirWorldData[0], markerToTipDirWorldData[1], markerToTipDirWorldData[2]);
   const vtkVector3d tipToMarkerWorld = -markerToTipWorld;
-  const vtkVector3d markerPosWorld = (gt.TipPositionWorld + tipNoise) + gt.StylusLength * tipToMarkerWorld;
+  const vtkVector3d markerPosWorld = gt.TipPosition_World + gt.StylusLength * tipToMarkerWorld;
 
   markerToWorld->SetElement(0, 3, markerPosWorld[0]);
   markerToWorld->SetElement(1, 3, markerPosWorld[1]);
@@ -89,15 +62,15 @@ static int TestGenerateRandomMarkerTransform(std::mt19937& rng)
 
   const double stylusLength = 150.0;
   const GroundTruth gt = GenerateGroundTruth(stylusLength, rng);
-  const vtkNew<vtkMatrix4x4> markerToWorld = GenerateRandomMarkerTransform(gt, vtkVector3d(0, 0, 0), rng);
+  const vtkNew<vtkMatrix4x4> markerToWorld = GenerateRandomMarkerTransform(gt, rng);
 
   // The stylus tip in marker coordinates should map to the ground truth tip position in world coordinates
-  const vtkVector4d tipMarker(gt.TipPositionMarker[0], gt.TipPositionMarker[1], gt.TipPositionMarker[2], 1.0);
+  const vtkVector4d tipMarker(gt.TipPosition_Marker[0], gt.TipPosition_Marker[1], gt.TipPosition_Marker[2], 1.0);
   vtkVector4d tipWorld;
   markerToWorld->MultiplyPoint(tipMarker.GetData(), tipWorld.GetData());
 
   const double tolerance = 1e-9;
-  const double distance = (vtkVector3d(tipWorld.GetData()) - gt.TipPositionWorld).Norm();
+  const double distance = (vtkVector3d(tipWorld.GetData()) - gt.TipPosition_World).Norm();
 
   if (distance > tolerance)
   {
@@ -114,10 +87,7 @@ static int TestPivotCalibration(vtkIGSIOPivotCalibrationAlgo* pivotAlgo, double 
   LOG_INFO("Running TestPivotCalibration (stylusLength=" << stylusLength << ", tipSigma=" << stylusTipSigma << ", errorTolerance=" << errorTolerance << ")...");
 
   // Generate ground truth
-  GroundTruth gt = GenerateGroundTruth(stylusLength, rng);
-
-  // Normal distribution for tip position noise
-  std::normal_distribution<double> noiseDist(0.0, stylusTipSigma);
+  const GroundTruth gt = GenerateGroundTruth(stylusLength, rng);
 
   // Target number of points
   const int targetNumberOfPoints = pivotAlgo->GetMaximumNumberOfPoseBuckets() * pivotAlgo->GetPoseBucketSize();
@@ -127,9 +97,10 @@ static int TestPivotCalibration(vtkIGSIOPivotCalibrationAlgo* pivotAlgo, double 
   const int maxIterations = 5 * targetNumberOfPoints; // pivotAlgo can reject points, so we keep trying at most maxIterations times
   for (int iteration = 0; iteration < maxIterations && pivotAlgo->GetNumberOfCalibrationPoints() < targetNumberOfPoints; ++iteration)
   {
-    const vtkVector3d tipNoise = noiseDist(rng) * GenerateRandomDirection(rng);
-    const vtkNew<vtkMatrix4x4> markerToWorld = GenerateRandomMarkerTransform(gt, tipNoise, rng);
-    pivotAlgo->InsertNextCalibrationPoint(markerToWorld);
+    const vtkNew<vtkMatrix4x4> markerToWorld = GenerateRandomMarkerTransform(gt, rng);
+    const vtkNew<vtkMatrix4x4> markerToWorldPlusNoise = ApplyRandomPerturbation(markerToWorld, 0, stylusTipSigma, rng);
+
+    pivotAlgo->InsertNextCalibrationPoint(markerToWorldPlusNoise);
   }
 
   // Check if we collected enough points
@@ -161,12 +132,12 @@ static int TestPivotCalibration(vtkIGSIOPivotCalibrationAlgo* pivotAlgo, double 
   double computedTip[4];
   tipToMarker->MultiplyPoint(origin, computedTip);
 
-  const double tipError = std::sqrt(vtkMath::Distance2BetweenPoints(computedTip, gt.TipPositionMarker.GetData()));
+  const double tipError = std::sqrt(vtkMath::Distance2BetweenPoints(computedTip, gt.TipPosition_Marker.GetData()));
   const double rmse = pivotAlgo->GetPivotCalibrationErrorMm();
 
   LOG_INFO("  RMSE: " << rmse << " mm");
   LOG_INFO("  Tip error: " << tipError << " mm");
-  LOG_INFO("  Ground truth tip: (" << gt.TipPositionMarker[0] << ", " << gt.TipPositionMarker[1] << ", " << gt.TipPositionMarker[2] << ")");
+  LOG_INFO("  Ground truth tip: (" << gt.TipPosition_Marker[0] << ", " << gt.TipPosition_Marker[1] << ", " << gt.TipPosition_Marker[2] << ")");
   LOG_INFO("  Computed tip: (" << computedTip[0] << ", " << computedTip[1] << ", " << computedTip[2] << ")");
 
   if (tipError >= errorTolerance)

--- a/IGSIOCalibration/Testing/vtkIGSIOPivotCalibrationTest.cxx
+++ b/IGSIOCalibration/Testing/vtkIGSIOPivotCalibrationTest.cxx
@@ -38,18 +38,18 @@ static vtkNew<vtkMatrix4x4> GenerateRandomMarkerTransform(const GroundTruth& gt,
 {
   vtkNew<vtkMatrix4x4> markerToWorld = GenerateRandomRotationMatrix(rng);
 
-  const vtkVector4d markerToTipDir(gt.TipDir_Marker[0], gt.TipDir_Marker[1], gt.TipDir_Marker[2], 0);
-  double markerToTipDirWorldData[4];
+  const vtkVector4d tipDir_Marker(gt.TipDir_Marker[0], gt.TipDir_Marker[1], gt.TipDir_Marker[2], 0);
+  double tipDirData_World[4];
 
-  markerToWorld->MultiplyPoint(markerToTipDir.GetData(), markerToTipDirWorldData);
+  markerToWorld->MultiplyPoint(tipDir_Marker.GetData(), tipDirData_World);
 
-  const vtkVector3d markerToTipWorld(markerToTipDirWorldData[0], markerToTipDirWorldData[1], markerToTipDirWorldData[2]);
-  const vtkVector3d tipToMarkerWorld = -markerToTipWorld;
-  const vtkVector3d markerPosWorld = gt.TipPosition_World + gt.StylusLength * tipToMarkerWorld;
+  const vtkVector3d tipDir_World(tipDirData_World[0], tipDirData_World[1], tipDirData_World[2]);
+  const vtkVector3d tipToMarker_World = -tipDir_World;
+  const vtkVector3d markerPos_World = gt.TipPosition_World + gt.StylusLength * tipToMarker_World;
 
-  markerToWorld->SetElement(0, 3, markerPosWorld[0]);
-  markerToWorld->SetElement(1, 3, markerPosWorld[1]);
-  markerToWorld->SetElement(2, 3, markerPosWorld[2]);
+  markerToWorld->SetElement(0, 3, markerPos_World[0]);
+  markerToWorld->SetElement(1, 3, markerPos_World[1]);
+  markerToWorld->SetElement(2, 3, markerPos_World[2]);
 
   return markerToWorld;
 }
@@ -65,12 +65,12 @@ static int TestGenerateRandomMarkerTransform(std::mt19937& rng)
   const vtkNew<vtkMatrix4x4> markerToWorld = GenerateRandomMarkerTransform(gt, rng);
 
   // The stylus tip in marker coordinates should map to the ground truth tip position in world coordinates
-  const vtkVector4d tipMarker(gt.TipPosition_Marker[0], gt.TipPosition_Marker[1], gt.TipPosition_Marker[2], 1.0);
-  vtkVector4d tipWorld;
-  markerToWorld->MultiplyPoint(tipMarker.GetData(), tipWorld.GetData());
+  const vtkVector4d tip_Marker(gt.TipPosition_Marker[0], gt.TipPosition_Marker[1], gt.TipPosition_Marker[2], 1.0);
+  vtkVector4d tip_World;
+  markerToWorld->MultiplyPoint(tip_Marker.GetData(), tip_World.GetData());
 
   const double tolerance = 1e-9;
-  const double distance = (vtkVector3d(tipWorld.GetData()) - gt.TipPosition_World).Norm();
+  const double distance = (vtkVector3d(tip_World.GetData()) - gt.TipPosition_World).Norm();
 
   if (distance > tolerance)
   {

--- a/IGSIOCalibration/Testing/vtkIGSIOPivotCalibrationTest.cxx
+++ b/IGSIOCalibration/Testing/vtkIGSIOPivotCalibrationTest.cxx
@@ -1,0 +1,263 @@
+#include "vtkIGSIOPivotCalibrationAlgo.h"
+
+#include <vtkMath.h>
+#include <vtkMatrix4x4.h>
+#include <vtkNew.h>
+#include <vtkTransform.h>
+#include <vtkVectorOperators.h>
+
+#include <cmath>
+#include <iostream>
+#include <random>
+
+struct GroundTruth
+{
+  vtkVector3d TipPositionWorld;  // Fixed pivot point in world coordinates
+  vtkVector3d TipPositionMarker; // Fixed pivot point in marker coordinates
+  vtkVector3d TipDir;            // The unit vector direction from the stylus marker to the tip in marker coordinates
+  double StylusLength;           // Length from tracker origin to tip
+};
+
+static vtkVector3d GenerateRandomDirection(std::mt19937& rng)
+{
+  std::uniform_real_distribution<double> distTheta(0.0, 2 * vtkMath::Pi());
+  std::uniform_real_distribution<double> distZ(-1.0, 1.0);
+
+  const double theta = distTheta(rng);
+  const double z = distZ(rng);
+  const double r = std::sqrt(1.0 - z * z);
+
+  return vtkVector3d(r * std::cos(theta), r * std::sin(theta), z);
+}
+
+static vtkNew<vtkMatrix4x4> GenerateRandomRotationMatrix(std::mt19937& rng)
+{
+  vtkVector3d axis = GenerateRandomDirection(rng);
+  std::uniform_real_distribution<double> distAngle(0.0, 360.0);
+  double angleDegrees = distAngle(rng);
+
+  vtkNew<vtkTransform> transform;
+  transform->RotateWXYZ(angleDegrees, axis.GetData());
+
+  vtkNew<vtkMatrix4x4> rotation;
+  transform->GetMatrix(rotation);
+
+  return rotation;
+}
+
+static GroundTruth GenerateGroundTruth(double stylusLength, std::mt19937& rng)
+{
+  std::uniform_real_distribution<double> dist(-500.0, 500.0);
+
+  const vtkVector3d dir = GenerateRandomDirection(rng);
+
+  GroundTruth gt;
+  gt.TipPositionWorld = vtkVector3d(dist(rng), dist(rng), dist(rng));
+  gt.TipPositionMarker = stylusLength * dir;
+  gt.TipDir = dir;
+  gt.StylusLength = stylusLength;
+  return gt;
+}
+
+// Generates a random MarkerToWorld transform: maps points in marker coordinates to world coordinates.
+// tipNoise is added to the tip position to simulate non-steady surface.
+static vtkNew<vtkMatrix4x4> GenerateRandomMarkerTransform(const GroundTruth& gt, const vtkVector3d& tipNoise, std::mt19937& rng)
+{
+  vtkNew<vtkMatrix4x4> markerToWorld = GenerateRandomRotationMatrix(rng);
+
+  const vtkVector4d markerToTipDir(gt.TipDir[0], gt.TipDir[1], gt.TipDir[2], 0);
+  double markerToTipDirWorldData[4];
+
+  markerToWorld->MultiplyPoint(markerToTipDir.GetData(), markerToTipDirWorldData);
+
+  const vtkVector3d markerToTipWorld(markerToTipDirWorldData[0], markerToTipDirWorldData[1], markerToTipDirWorldData[2]);
+  const vtkVector3d tipToMarkerWorld = -markerToTipWorld;
+  const vtkVector3d markerPosWorld = (gt.TipPositionWorld + tipNoise) + gt.StylusLength * tipToMarkerWorld;
+
+  markerToWorld->SetElement(0, 3, markerPosWorld[0]);
+  markerToWorld->SetElement(1, 3, markerPosWorld[1]);
+  markerToWorld->SetElement(2, 3, markerPosWorld[2]);
+
+  return markerToWorld;
+}
+
+// A sanity check test to make sure that the generated marker transforms work as expected.
+// Specifically: the generated marker transforms should leave the tip position fixed.
+static int TestGenerateRandomMarkerTransform(std::mt19937& rng)
+{
+  LOG_INFO("Running TestGenerateRandomMarkerTransform...");
+
+  const double stylusLength = 150.0;
+  const GroundTruth gt = GenerateGroundTruth(stylusLength, rng);
+  const vtkNew<vtkMatrix4x4> markerToWorld = GenerateRandomMarkerTransform(gt, vtkVector3d(0, 0, 0), rng);
+
+  // The stylus tip in marker coordinates should map to the ground truth tip position in world coordinates
+  const vtkVector4d tipMarker(gt.TipPositionMarker[0], gt.TipPositionMarker[1], gt.TipPositionMarker[2], 1.0);
+  vtkVector4d tipWorld;
+  markerToWorld->MultiplyPoint(tipMarker.GetData(), tipWorld.GetData());
+
+  const double tolerance = 1e-9;
+  const double distance = (vtkVector3d(tipWorld.GetData()) - gt.TipPositionWorld).Norm();
+
+  if (distance > tolerance)
+  {
+    LOG_ERROR("ERROR: Tip position mismatch! Distance between expected tip and computed tip = " << distance);
+    return EXIT_FAILURE;
+  }
+
+  LOG_INFO("  PASSED");
+  return EXIT_SUCCESS;
+}
+
+static int TestPivotCalibration(vtkIGSIOPivotCalibrationAlgo* pivotAlgo, double stylusLength, double stylusTipSigma, double errorTolerance, std::mt19937& rng)
+{
+  LOG_INFO("Running TestPivotCalibration (stylusLength=" << stylusLength << ", tipSigma=" << stylusTipSigma << ", errorTolerance=" << errorTolerance << ")...");
+
+  // Generate ground truth
+  GroundTruth gt = GenerateGroundTruth(stylusLength, rng);
+
+  // Normal distribution for tip position noise
+  std::normal_distribution<double> noiseDist(0.0, stylusTipSigma);
+
+  // Target number of points
+  const int targetNumberOfPoints = pivotAlgo->GetMaximumNumberOfPoseBuckets() * pivotAlgo->GetPoseBucketSize();
+
+  // Feed marker transforms
+  pivotAlgo->RemoveAllCalibrationPoints();
+  const int maxIterations = 500; // pivotAlgo can reject points, so we keep trying at most maxIterations times
+  for (int iteration = 0; iteration < maxIterations && pivotAlgo->GetNumberOfCalibrationPoints() < targetNumberOfPoints; ++iteration)
+  {
+    const vtkVector3d tipNoise = noiseDist(rng) * GenerateRandomDirection(rng);
+    const vtkNew<vtkMatrix4x4> markerToWorld = GenerateRandomMarkerTransform(gt, tipNoise, rng);
+    pivotAlgo->InsertNextCalibrationPoint(markerToWorld);
+  }
+
+  // Check if we collected enough points
+  const int numPoses = pivotAlgo->GetNumberOfCalibrationPoints();
+  if (numPoses < targetNumberOfPoints)
+  {
+    LOG_ERROR("ERROR: Only collected " << numPoses << " poses out of " << targetNumberOfPoints << " required");
+    return EXIT_FAILURE;
+  }
+
+  // Perform calibration
+  const igsioStatus status = pivotAlgo->DoPivotCalibration(nullptr, true);
+  if (status != IGSIO_SUCCESS)
+  {
+    LOG_ERROR("ERROR: Pivot calibration failed");
+    return EXIT_FAILURE;
+  }
+
+  // Get the result
+  vtkMatrix4x4* tipToMarker = pivotAlgo->GetPivotPointToMarkerTransformMatrix();
+  if (!tipToMarker)
+  {
+    LOG_ERROR("ERROR: Failed to get calibration result matrix");
+    return EXIT_FAILURE;
+  }
+
+  // Compute the tip location in marker coordinates by transforming the origin
+  const double origin[4] = { 0, 0, 0, 1 };
+  double computedTip[4];
+  tipToMarker->MultiplyPoint(origin, computedTip);
+
+  const double tipError = std::sqrt(vtkMath::Distance2BetweenPoints(computedTip, gt.TipPositionMarker.GetData()));
+  const double rmse = pivotAlgo->GetPivotCalibrationErrorMm();
+
+  LOG_INFO("  RMSE: " << rmse << " mm");
+  LOG_INFO("  Tip error: " << tipError << " mm");
+  LOG_INFO("  Ground truth tip: (" << gt.TipPositionMarker[0] << ", " << gt.TipPositionMarker[1] << ", " << gt.TipPositionMarker[2] << ")");
+  LOG_INFO("  Computed tip: (" << computedTip[0] << ", " << computedTip[1] << ", " << computedTip[2] << ")");
+
+  if (tipError >= errorTolerance)
+  {
+    LOG_ERROR("ERROR: Tip error " << tipError << " exceeds tolerance " << errorTolerance);
+    return EXIT_FAILURE;
+  }
+
+  LOG_INFO("  PASSED");
+  return EXIT_SUCCESS;
+}
+
+int main(int argc, char* argv[])
+{
+  std::mt19937 rng(42);
+  int numberOfErrors = 0;
+
+  vtkNew<vtkIGSIOPivotCalibrationAlgo> pivotAlgo;
+  pivotAlgo->SetValidateInputBufferEnabled(true);
+  pivotAlgo->SetPoseBucketSize(10);
+  pivotAlgo->SetMaximumNumberOfPoseBuckets(10);
+
+  // Test the transform generation helper
+  if (TestGenerateRandomMarkerTransform(rng) != EXIT_SUCCESS)
+  {
+    numberOfErrors++;
+  }
+
+  // Exact (no noise)
+  if (TestPivotCalibration(pivotAlgo, 50.0, 0.0, 1e-6, rng) != EXIT_SUCCESS)
+  {
+    numberOfErrors++;
+  }
+  if (TestPivotCalibration(pivotAlgo, 150.0, 0.0, 1e-6, rng) != EXIT_SUCCESS)
+  {
+    numberOfErrors++;
+  }
+  if (TestPivotCalibration(pivotAlgo, 300.0, 0.0, 1e-6, rng) != EXIT_SUCCESS)
+  {
+    numberOfErrors++;
+  }
+
+  // Small noise
+  if (TestPivotCalibration(pivotAlgo, 50.0, 0.1, 0.05, rng) != EXIT_SUCCESS)
+  {
+    numberOfErrors++;
+  }
+  if (TestPivotCalibration(pivotAlgo, 150.0, 0.1, 0.05, rng) != EXIT_SUCCESS)
+  {
+    numberOfErrors++;
+  }
+  if (TestPivotCalibration(pivotAlgo, 300.0, 0.1, 0.05, rng) != EXIT_SUCCESS)
+  {
+    numberOfErrors++;
+  }
+
+  // Medium noise
+  if (TestPivotCalibration(pivotAlgo, 50.0, 0.5, 0.1, rng) != EXIT_SUCCESS)
+  {
+    numberOfErrors++;
+  }
+  if (TestPivotCalibration(pivotAlgo, 150.0, 0.5, 0.1, rng) != EXIT_SUCCESS)
+  {
+    numberOfErrors++;
+  }
+  if (TestPivotCalibration(pivotAlgo, 300.0, 0.5, 0.1, rng) != EXIT_SUCCESS)
+  {
+    numberOfErrors++;
+  }
+
+  // Higher noise
+  if (TestPivotCalibration(pivotAlgo, 50.0, 3.0, 1.0, rng) != EXIT_SUCCESS)
+  {
+    numberOfErrors++;
+  }
+  if (TestPivotCalibration(pivotAlgo, 150.0, 3.0, 1.0, rng) != EXIT_SUCCESS)
+  {
+    numberOfErrors++;
+  }
+  if (TestPivotCalibration(pivotAlgo, 300.0, 3.0, 1.0, rng) != EXIT_SUCCESS)
+  {
+    numberOfErrors++;
+  }
+
+  LOG_INFO("=== Summary ===");
+  if (numberOfErrors > 0)
+  {
+    LOG_INFO("FAILED: " << numberOfErrors << " test(s) failed");
+    return EXIT_FAILURE;
+  }
+
+  LOG_INFO("All tests PASSED");
+  return EXIT_SUCCESS;
+}

--- a/IGSIOCalibration/Testing/vtkIGSIOPivotCalibrationTest.cxx
+++ b/IGSIOCalibration/Testing/vtkIGSIOPivotCalibrationTest.cxx
@@ -124,7 +124,7 @@ static int TestPivotCalibration(vtkIGSIOPivotCalibrationAlgo* pivotAlgo, double 
 
   // Feed marker transforms
   pivotAlgo->RemoveAllCalibrationPoints();
-  const int maxIterations = 500; // pivotAlgo can reject points, so we keep trying at most maxIterations times
+  const int maxIterations = 5 * targetNumberOfPoints; // pivotAlgo can reject points, so we keep trying at most maxIterations times
   for (int iteration = 0; iteration < maxIterations && pivotAlgo->GetNumberOfCalibrationPoints() < targetNumberOfPoints; ++iteration)
   {
     const vtkVector3d tipNoise = noiseDist(rng) * GenerateRandomDirection(rng);

--- a/IGSIOCalibration/Testing/vtkIGSIOSpinCalibrationTest.cxx
+++ b/IGSIOCalibration/Testing/vtkIGSIOSpinCalibrationTest.cxx
@@ -1,0 +1,260 @@
+#include "vtkIGSIOSpinCalibrationAlgo.h"
+#include "Utils.h"
+
+#include <vtkMath.h>
+#include <vtkMatrix4x4.h>
+#include <vtkNew.h>
+#include <vtkTransform.h>
+#include <vtkVectorOperators.h>
+
+#include <cmath>
+#include <random>
+
+struct GroundTruth
+{
+  vtkVector3d TipPositionWorld;  // Fixed tip position in world coordinates
+  vtkVector3d TipPositionMarker; // Tip position in marker coordinates (on spin axis)
+  vtkVector3d SpinAxisMarker;    // Unit spin axis in marker coordinates
+  double MarkerRadius;           // Perpendicular distance from marker origin to spin axis
+};
+
+static GroundTruth GenerateGroundTruth(double stylusLength, double markerRadius, std::mt19937& rng)
+{
+  std::uniform_real_distribution<double> dist(-500.0, 500.0);
+
+  // Random spin axis in marker coordinates
+  const vtkVector3d spinAxis = GenerateRandomDirection(rng);
+
+  // Compute tip position in marker coordinates
+  // The marker origin is at perpendicular distance markerRadius from the spin axis
+  const double h = std::sqrt(stylusLength * stylusLength - markerRadius * markerRadius);
+  const vtkVector3d perpDir = GenerateRandomPerpendicularDirection(spinAxis, rng);
+  const vtkVector3d tipPositionMarker = h * spinAxis + markerRadius * perpDir;
+
+  GroundTruth gt;
+  gt.TipPositionWorld = vtkVector3d(dist(rng), dist(rng), dist(rng));
+  gt.TipPositionMarker = tipPositionMarker;
+  gt.SpinAxisMarker = spinAxis;
+  gt.MarkerRadius = markerRadius;
+  return gt;
+}
+
+static vtkVector3d ComputeSpinAxisWorld(vtkMatrix4x4* markerToWorld, const vtkVector3d& spinAxisMarker)
+{
+  const vtkVector4d axisMarker(spinAxisMarker[0], spinAxisMarker[1], spinAxisMarker[2], 0);
+  double axisWorld[4];
+  markerToWorld->MultiplyPoint(axisMarker.GetData(), axisWorld);
+
+  return vtkVector3d(axisWorld);
+}
+
+static vtkNew<vtkMatrix4x4> GenerateInitialMarkerTransform(const GroundTruth& gt, std::mt19937& rng)
+{
+  vtkNew<vtkMatrix4x4> markerToWorld = GenerateRandomRotationMatrix(rng);
+
+  // Transform tip from marker to world and compute marker origin position
+  const vtkVector4d tipMarker(gt.TipPositionMarker[0], gt.TipPositionMarker[1], gt.TipPositionMarker[2], 0);
+  double tipWorldOffset[4];
+  markerToWorld->MultiplyPoint(tipMarker.GetData(), tipWorldOffset);
+
+  // markerOriginWorld + tipWorldOffset = tipPositionWorld
+  // markerOriginWorld = tipPositionWorld - tipWorldOffset
+  const vtkVector3d markerOriginWorld = gt.TipPositionWorld - vtkVector3d(tipWorldOffset);
+
+  markerToWorld->SetElement(0, 3, markerOriginWorld[0]);
+  markerToWorld->SetElement(1, 3, markerOriginWorld[1]);
+  markerToWorld->SetElement(2, 3, markerOriginWorld[2]);
+
+  return markerToWorld;
+}
+
+// A sanity check test to make sure that the generated initial marker transform works as expected.
+static int TestGenerateInitialMarkerTransform(std::mt19937& rng)
+{
+  LOG_INFO("Running TestGenerateInitialMarkerTransform...");
+
+  const double stylusLength = 150.0;
+  const double markerRadius = 30.0;
+
+  const GroundTruth gt = GenerateGroundTruth(stylusLength, markerRadius, rng);
+  const vtkNew<vtkMatrix4x4> markerToWorld = GenerateInitialMarkerTransform(gt, rng);
+
+  // Verify tip in marker coordinates maps to tip in world coordinates
+  const vtkVector4d tipMarker(gt.TipPositionMarker[0], gt.TipPositionMarker[1], gt.TipPositionMarker[2], 1.0);
+  vtkVector4d tipWorld;
+  markerToWorld->MultiplyPoint(tipMarker.GetData(), tipWorld.GetData());
+
+  const double tolerance = 1e-9;
+  const double distance = (vtkVector3d(tipWorld.GetData()) - gt.TipPositionWorld).Norm();
+
+  if (distance > tolerance)
+  {
+    LOG_ERROR("ERROR: Tip position mismatch! Distance = " << distance);
+    return EXIT_FAILURE;
+  }
+
+  LOG_INFO("  PASSED");
+  return EXIT_SUCCESS;
+}
+
+static int TestSpinCalibration(vtkIGSIOSpinCalibrationAlgo* spinAlgo,
+                               double stylusLength,
+                               double markerRadius,
+                               double rotationNoise,
+                               double errorToleranceDegrees,
+                               std::mt19937& rng)
+{
+  LOG_INFO("Running TestSpinCalibration (stylusLength=" << stylusLength << ", markerRadius=" << markerRadius << ", noise=" << rotationNoise << "°)...");
+
+  // Generate ground truth
+  const GroundTruth gt = GenerateGroundTruth(stylusLength, markerRadius, rng);
+
+  // Generate initial marker transform
+  const vtkNew<vtkMatrix4x4> initialMarkerToWorld = GenerateInitialMarkerTransform(gt, rng);
+  const vtkVector3d spinAxisWorld = ComputeSpinAxisWorld(initialMarkerToWorld, gt.SpinAxisMarker);
+
+  // Clear previous calibration points
+  spinAlgo->RemoveAllCalibrationPoints();
+
+  const int targetNumberOfPoints = spinAlgo->GetMaximumNumberOfPoseBuckets() * spinAlgo->GetPoseBucketSize();
+  const double angleIncrementDegrees = 2.0 * 360.0 / targetNumberOfPoints; // Two revolutions
+  const int maxIterations = targetNumberOfPoints * 5;
+
+  // Feed continuous marker transforms (spinning around axis)
+  for (int i = 0; i < maxIterations && spinAlgo->GetNumberOfCalibrationPoints() < targetNumberOfPoints; ++i)
+  {
+    const double angle = i * angleIncrementDegrees;
+    const vtkNew<vtkMatrix4x4> markerToWorld = RotateAroundAxisAtPoint(initialMarkerToWorld, spinAxisWorld, gt.TipPositionWorld, angle);
+    const vtkNew<vtkMatrix4x4> markerToWorldPlusNoise = ApplyRandomPerturbation(markerToWorld, rotationNoise, rng);
+
+    spinAlgo->InsertNextCalibrationPoint(markerToWorldPlusNoise);
+  }
+
+  // Check if we collected enough points
+  const int numPoses = spinAlgo->GetNumberOfCalibrationPoints();
+  if (numPoses < targetNumberOfPoints)
+  {
+    LOG_ERROR("ERROR: Only collected " << numPoses << " poses out of " << targetNumberOfPoints << " required");
+    return EXIT_FAILURE;
+  }
+
+  // Perform calibration
+  const igsioStatus status = spinAlgo->DoSpinCalibration(nullptr, false, true);
+  if (status != IGSIO_SUCCESS)
+  {
+    LOG_ERROR("ERROR: Spin calibration failed");
+    return EXIT_FAILURE;
+  }
+
+  // Get the result
+  vtkMatrix4x4* tipToMarker = spinAlgo->GetPivotPointToMarkerTransformMatrix();
+
+  // Extract Z-axis from tipToMarker by transforming (0, 0, 1, 0) - this is the spin axis in marker coordinates
+  const double zAxis[4] = { 0, 0, 1, 0 };
+  double computedSpinAxisMarkerData[4];
+  tipToMarker->MultiplyPoint(zAxis, computedSpinAxisMarkerData);
+  const vtkVector3d computedSpinAxisMarker(computedSpinAxisMarkerData);
+
+  // Compare with ground truth: compute angle between axes in degrees
+  // Axes should be parallel (either same or opposite direction)
+  const double dotProduct = computedSpinAxisMarker.Dot(gt.SpinAxisMarker);
+  const double axisErrorDegrees = vtkMath::DegreesFromRadians(std::acos(std::min(1.0, std::abs(dotProduct))));
+
+  const double rmse = spinAlgo->GetSpinCalibrationErrorMm();
+
+  LOG_INFO("  RMSE: " << rmse << " mm");
+  LOG_INFO("  Axis error: " << axisErrorDegrees << " degrees");
+
+  if (axisErrorDegrees >= errorToleranceDegrees)
+  {
+    LOG_ERROR("ERROR: Axis error " << axisErrorDegrees << " degrees exceeds tolerance " << errorToleranceDegrees << " degrees");
+    return EXIT_FAILURE;
+  }
+
+  LOG_INFO("  PASSED");
+  return EXIT_SUCCESS;
+}
+
+int main(int argc, char* argv[])
+{
+  std::mt19937 rng(42);
+  int numberOfErrors = 0;
+
+  vtkNew<vtkIGSIOSpinCalibrationAlgo> spinAlgo;
+  spinAlgo->SetValidateInputBufferEnabled(true);
+  spinAlgo->SetPoseBucketSize(10);
+  spinAlgo->SetMaximumNumberOfPoseBuckets(10);
+
+  // Test helper functions
+  if (TestGenerateInitialMarkerTransform(rng) != EXIT_SUCCESS)
+  {
+    numberOfErrors++;
+  }
+
+  // Exact tests (no noise) - various stylus lengths and marker radii
+  // stylusLength, markerRadius, rotationNoiseDegrees, errorToleranceDegrees
+  if (TestSpinCalibration(spinAlgo, 50.0, 10.0, 0.0, 1e-6, rng) != EXIT_SUCCESS)
+  {
+    numberOfErrors++;
+  }
+  if (TestSpinCalibration(spinAlgo, 150.0, 20.0, 0.0, 1e-6, rng) != EXIT_SUCCESS)
+  {
+    numberOfErrors++;
+  }
+  if (TestSpinCalibration(spinAlgo, 300.0, 30.0, 0.0, 1e-6, rng) != EXIT_SUCCESS)
+  {
+    numberOfErrors++;
+  }
+
+  // Small noise tests (0.5° tracking noise) - simulating good tracking conditions
+  if (TestSpinCalibration(spinAlgo, 50.0, 10.0, 0.5, 0.5, rng) != EXIT_SUCCESS)
+  {
+    numberOfErrors++;
+  }
+  if (TestSpinCalibration(spinAlgo, 150.0, 20.0, 0.5, 0.5, rng) != EXIT_SUCCESS)
+  {
+    numberOfErrors++;
+  }
+  if (TestSpinCalibration(spinAlgo, 300.0, 30.0, 0.5, 0.5, rng) != EXIT_SUCCESS)
+  {
+    numberOfErrors++;
+  }
+
+  // Medium noise tests (5.0° tracking noise) - simulating typical tracking conditions
+  if (TestSpinCalibration(spinAlgo, 50.0, 10.0, 5.0, 5.0, rng) != EXIT_SUCCESS)
+  {
+    numberOfErrors++;
+  }
+  if (TestSpinCalibration(spinAlgo, 150.0, 20.0, 5.0, 5.0, rng) != EXIT_SUCCESS)
+  {
+    numberOfErrors++;
+  }
+  if (TestSpinCalibration(spinAlgo, 300.0, 30.0, 5.0, 5.0, rng) != EXIT_SUCCESS)
+  {
+    numberOfErrors++;
+  }
+
+  // Higher noise tests (10.0° tracking noise) - simulating challenging conditions
+  if (TestSpinCalibration(spinAlgo, 50.0, 10.0, 10.0, 10.0, rng) != EXIT_SUCCESS)
+  {
+    numberOfErrors++;
+  }
+  if (TestSpinCalibration(spinAlgo, 150.0, 20.0, 10.0, 10.0, rng) != EXIT_SUCCESS)
+  {
+    numberOfErrors++;
+  }
+  if (TestSpinCalibration(spinAlgo, 300.0, 30.0, 10.0, 10.0, rng) != EXIT_SUCCESS)
+  {
+    numberOfErrors++;
+  }
+
+  LOG_INFO("=== Summary ===");
+  if (numberOfErrors > 0)
+  {
+    LOG_INFO("FAILED: " << numberOfErrors << " test(s) failed");
+    return EXIT_FAILURE;
+  }
+
+  LOG_INFO("All tests PASSED");
+  return EXIT_SUCCESS;
+}

--- a/IGSIOCalibration/Testing/vtkIGSIOSpinCalibrationTest.cxx
+++ b/IGSIOCalibration/Testing/vtkIGSIOSpinCalibrationTest.cxx
@@ -29,23 +29,23 @@ static GroundTruth GenerateGroundTruth(double stylusLength, double markerRadius,
   // The marker origin is at perpendicular distance markerRadius from the spin axis
   const double h = std::sqrt(stylusLength * stylusLength - markerRadius * markerRadius);
   const vtkVector3d perpDir = GenerateRandomPerpendicularDirection(spinAxis, rng);
-  const vtkVector3d tipPositionMarker = h * spinAxis + markerRadius * perpDir;
+  const vtkVector3d tipPosition_Marker = h * spinAxis + markerRadius * perpDir;
 
   GroundTruth gt;
   gt.TipPosition_World = vtkVector3d(dist(rng), dist(rng), dist(rng));
-  gt.TipPosition_Marker = tipPositionMarker;
+  gt.TipPosition_Marker = tipPosition_Marker;
   gt.SpinAxis_Marker = spinAxis;
   gt.MarkerRadius = markerRadius;
   return gt;
 }
 
-static vtkVector3d ComputeSpinAxisWorld(vtkMatrix4x4* markerToWorld, const vtkVector3d& spinAxisMarker)
+static vtkVector3d ComputeSpinAxisWorld(vtkMatrix4x4* markerToWorld, const vtkVector3d& spinAxis_Marker)
 {
-  const vtkVector4d axisMarker(spinAxisMarker[0], spinAxisMarker[1], spinAxisMarker[2], 0);
-  double axisWorld[4];
-  markerToWorld->MultiplyPoint(axisMarker.GetData(), axisWorld);
+  const vtkVector4d axis_Marker(spinAxis_Marker[0], spinAxis_Marker[1], spinAxis_Marker[2], 0);
+  double axis_World[4];
+  markerToWorld->MultiplyPoint(axis_Marker.GetData(), axis_World);
 
-  return vtkVector3d(axisWorld);
+  return vtkVector3d(axis_World);
 }
 
 static vtkNew<vtkMatrix4x4> GenerateInitialMarkerTransform(const GroundTruth& gt, std::mt19937& rng)
@@ -53,17 +53,17 @@ static vtkNew<vtkMatrix4x4> GenerateInitialMarkerTransform(const GroundTruth& gt
   vtkNew<vtkMatrix4x4> markerToWorld = GenerateRandomRotationMatrix(rng);
 
   // Transform tip from marker to world and compute marker origin position
-  const vtkVector4d tipMarker(gt.TipPosition_Marker[0], gt.TipPosition_Marker[1], gt.TipPosition_Marker[2], 0);
-  double tipWorldOffset[4];
-  markerToWorld->MultiplyPoint(tipMarker.GetData(), tipWorldOffset);
+  const vtkVector4d tip_Marker(gt.TipPosition_Marker[0], gt.TipPosition_Marker[1], gt.TipPosition_Marker[2], 0);
+  double tipOffset_World[4];
+  markerToWorld->MultiplyPoint(tip_Marker.GetData(), tipOffset_World);
 
-  // markerOriginWorld + tipWorldOffset = tipPositionWorld
-  // markerOriginWorld = tipPositionWorld - tipWorldOffset
-  const vtkVector3d markerOriginWorld = gt.TipPosition_World - vtkVector3d(tipWorldOffset);
+  // markerOrigin_World + tipOffset_World = tipPosition_World
+  // markerOrigin_World = tipPosition_World - tipOffset_World
+  const vtkVector3d markerOrigin_World = gt.TipPosition_World - vtkVector3d(tipOffset_World);
 
-  markerToWorld->SetElement(0, 3, markerOriginWorld[0]);
-  markerToWorld->SetElement(1, 3, markerOriginWorld[1]);
-  markerToWorld->SetElement(2, 3, markerOriginWorld[2]);
+  markerToWorld->SetElement(0, 3, markerOrigin_World[0]);
+  markerToWorld->SetElement(1, 3, markerOrigin_World[1]);
+  markerToWorld->SetElement(2, 3, markerOrigin_World[2]);
 
   return markerToWorld;
 }
@@ -80,12 +80,12 @@ static int TestGenerateInitialMarkerTransform(std::mt19937& rng)
   const vtkNew<vtkMatrix4x4> markerToWorld = GenerateInitialMarkerTransform(gt, rng);
 
   // Verify tip in marker coordinates maps to tip in world coordinates
-  const vtkVector4d tipMarker(gt.TipPosition_Marker[0], gt.TipPosition_Marker[1], gt.TipPosition_Marker[2], 1.0);
-  vtkVector4d tipWorld;
-  markerToWorld->MultiplyPoint(tipMarker.GetData(), tipWorld.GetData());
+  const vtkVector4d tip_Marker(gt.TipPosition_Marker[0], gt.TipPosition_Marker[1], gt.TipPosition_Marker[2], 1.0);
+  vtkVector4d tip_World;
+  markerToWorld->MultiplyPoint(tip_Marker.GetData(), tip_World.GetData());
 
   const double tolerance = 1e-9;
-  const double distance = (vtkVector3d(tipWorld.GetData()) - gt.TipPosition_World).Norm();
+  const double distance = (vtkVector3d(tip_World.GetData()) - gt.TipPosition_World).Norm();
 
   if (distance > tolerance)
   {
@@ -111,7 +111,7 @@ static int TestSpinCalibration(vtkIGSIOSpinCalibrationAlgo* spinAlgo,
 
   // Generate initial marker transform
   const vtkNew<vtkMatrix4x4> initialMarkerToWorld = GenerateInitialMarkerTransform(gt, rng);
-  const vtkVector3d spinAxisWorld = ComputeSpinAxisWorld(initialMarkerToWorld, gt.SpinAxis_Marker);
+  const vtkVector3d spinAxis_World = ComputeSpinAxisWorld(initialMarkerToWorld, gt.SpinAxis_Marker);
 
   // Clear previous calibration points
   spinAlgo->RemoveAllCalibrationPoints();
@@ -124,7 +124,7 @@ static int TestSpinCalibration(vtkIGSIOSpinCalibrationAlgo* spinAlgo,
   for (int i = 0; i < maxIterations && spinAlgo->GetNumberOfCalibrationPoints() < targetNumberOfPoints; ++i)
   {
     const double angle = i * angleIncrementDegrees;
-    const vtkNew<vtkMatrix4x4> markerToWorld = RotateAroundAxisAtPoint(initialMarkerToWorld, spinAxisWorld, gt.TipPosition_World, angle);
+    const vtkNew<vtkMatrix4x4> markerToWorld = RotateAroundAxisAtPoint(initialMarkerToWorld, spinAxis_World, gt.TipPosition_World, angle);
     const vtkNew<vtkMatrix4x4> markerToWorldPlusNoise = ApplyRandomPerturbation(markerToWorld, rotationNoise, 0, rng);
 
     spinAlgo->InsertNextCalibrationPoint(markerToWorldPlusNoise);

--- a/IGSIOCalibration/Testing/vtkIGSIOSpinCalibrationTest.cxx
+++ b/IGSIOCalibration/Testing/vtkIGSIOSpinCalibrationTest.cxx
@@ -12,10 +12,10 @@
 
 struct GroundTruth
 {
-  vtkVector3d TipPositionWorld;  // Fixed tip position in world coordinates
-  vtkVector3d TipPositionMarker; // Tip position in marker coordinates (on spin axis)
-  vtkVector3d SpinAxisMarker;    // Unit spin axis in marker coordinates
-  double MarkerRadius;           // Perpendicular distance from marker origin to spin axis
+  vtkVector3d TipPosition_World;  // Fixed tip position in world coordinates
+  vtkVector3d TipPosition_Marker; // Tip position in marker coordinates (on spin axis)
+  vtkVector3d SpinAxis_Marker;    // Unit spin axis in marker coordinates
+  double MarkerRadius;            // Perpendicular distance from marker origin to spin axis
 };
 
 static GroundTruth GenerateGroundTruth(double stylusLength, double markerRadius, std::mt19937& rng)
@@ -32,9 +32,9 @@ static GroundTruth GenerateGroundTruth(double stylusLength, double markerRadius,
   const vtkVector3d tipPositionMarker = h * spinAxis + markerRadius * perpDir;
 
   GroundTruth gt;
-  gt.TipPositionWorld = vtkVector3d(dist(rng), dist(rng), dist(rng));
-  gt.TipPositionMarker = tipPositionMarker;
-  gt.SpinAxisMarker = spinAxis;
+  gt.TipPosition_World = vtkVector3d(dist(rng), dist(rng), dist(rng));
+  gt.TipPosition_Marker = tipPositionMarker;
+  gt.SpinAxis_Marker = spinAxis;
   gt.MarkerRadius = markerRadius;
   return gt;
 }
@@ -53,13 +53,13 @@ static vtkNew<vtkMatrix4x4> GenerateInitialMarkerTransform(const GroundTruth& gt
   vtkNew<vtkMatrix4x4> markerToWorld = GenerateRandomRotationMatrix(rng);
 
   // Transform tip from marker to world and compute marker origin position
-  const vtkVector4d tipMarker(gt.TipPositionMarker[0], gt.TipPositionMarker[1], gt.TipPositionMarker[2], 0);
+  const vtkVector4d tipMarker(gt.TipPosition_Marker[0], gt.TipPosition_Marker[1], gt.TipPosition_Marker[2], 0);
   double tipWorldOffset[4];
   markerToWorld->MultiplyPoint(tipMarker.GetData(), tipWorldOffset);
 
   // markerOriginWorld + tipWorldOffset = tipPositionWorld
   // markerOriginWorld = tipPositionWorld - tipWorldOffset
-  const vtkVector3d markerOriginWorld = gt.TipPositionWorld - vtkVector3d(tipWorldOffset);
+  const vtkVector3d markerOriginWorld = gt.TipPosition_World - vtkVector3d(tipWorldOffset);
 
   markerToWorld->SetElement(0, 3, markerOriginWorld[0]);
   markerToWorld->SetElement(1, 3, markerOriginWorld[1]);
@@ -80,12 +80,12 @@ static int TestGenerateInitialMarkerTransform(std::mt19937& rng)
   const vtkNew<vtkMatrix4x4> markerToWorld = GenerateInitialMarkerTransform(gt, rng);
 
   // Verify tip in marker coordinates maps to tip in world coordinates
-  const vtkVector4d tipMarker(gt.TipPositionMarker[0], gt.TipPositionMarker[1], gt.TipPositionMarker[2], 1.0);
+  const vtkVector4d tipMarker(gt.TipPosition_Marker[0], gt.TipPosition_Marker[1], gt.TipPosition_Marker[2], 1.0);
   vtkVector4d tipWorld;
   markerToWorld->MultiplyPoint(tipMarker.GetData(), tipWorld.GetData());
 
   const double tolerance = 1e-9;
-  const double distance = (vtkVector3d(tipWorld.GetData()) - gt.TipPositionWorld).Norm();
+  const double distance = (vtkVector3d(tipWorld.GetData()) - gt.TipPosition_World).Norm();
 
   if (distance > tolerance)
   {
@@ -111,7 +111,7 @@ static int TestSpinCalibration(vtkIGSIOSpinCalibrationAlgo* spinAlgo,
 
   // Generate initial marker transform
   const vtkNew<vtkMatrix4x4> initialMarkerToWorld = GenerateInitialMarkerTransform(gt, rng);
-  const vtkVector3d spinAxisWorld = ComputeSpinAxisWorld(initialMarkerToWorld, gt.SpinAxisMarker);
+  const vtkVector3d spinAxisWorld = ComputeSpinAxisWorld(initialMarkerToWorld, gt.SpinAxis_Marker);
 
   // Clear previous calibration points
   spinAlgo->RemoveAllCalibrationPoints();
@@ -124,8 +124,8 @@ static int TestSpinCalibration(vtkIGSIOSpinCalibrationAlgo* spinAlgo,
   for (int i = 0; i < maxIterations && spinAlgo->GetNumberOfCalibrationPoints() < targetNumberOfPoints; ++i)
   {
     const double angle = i * angleIncrementDegrees;
-    const vtkNew<vtkMatrix4x4> markerToWorld = RotateAroundAxisAtPoint(initialMarkerToWorld, spinAxisWorld, gt.TipPositionWorld, angle);
-    const vtkNew<vtkMatrix4x4> markerToWorldPlusNoise = ApplyRandomPerturbation(markerToWorld, rotationNoise, rng);
+    const vtkNew<vtkMatrix4x4> markerToWorld = RotateAroundAxisAtPoint(initialMarkerToWorld, spinAxisWorld, gt.TipPosition_World, angle);
+    const vtkNew<vtkMatrix4x4> markerToWorldPlusNoise = ApplyRandomPerturbation(markerToWorld, rotationNoise, 0, rng);
 
     spinAlgo->InsertNextCalibrationPoint(markerToWorldPlusNoise);
   }
@@ -151,13 +151,13 @@ static int TestSpinCalibration(vtkIGSIOSpinCalibrationAlgo* spinAlgo,
 
   // Extract Z-axis from tipToMarker by transforming (0, 0, 1, 0) - this is the spin axis in marker coordinates
   const double zAxis[4] = { 0, 0, 1, 0 };
-  double computedSpinAxisMarkerData[4];
-  tipToMarker->MultiplyPoint(zAxis, computedSpinAxisMarkerData);
-  const vtkVector3d computedSpinAxisMarker(computedSpinAxisMarkerData);
+  double computedSpinAxis_MarkerData[4];
+  tipToMarker->MultiplyPoint(zAxis, computedSpinAxis_MarkerData);
+  const vtkVector3d computedSpinAxis_Marker(computedSpinAxis_MarkerData);
 
   // Compare with ground truth: compute angle between axes in degrees
   // Axes should be parallel (either same or opposite direction)
-  const double dotProduct = computedSpinAxisMarker.Dot(gt.SpinAxisMarker);
+  const double dotProduct = computedSpinAxis_Marker.Dot(gt.SpinAxis_Marker);
   const double axisErrorDegrees = vtkMath::DegreesFromRadians(std::acos(std::min(1.0, std::abs(dotProduct))));
 
   const double rmse = spinAlgo->GetSpinCalibrationErrorMm();

--- a/IGSIOCalibration/Testing/vtkIGSIOSpinCalibrationTest.cxx
+++ b/IGSIOCalibration/Testing/vtkIGSIOSpinCalibrationTest.cxx
@@ -27,9 +27,8 @@ static GroundTruth GenerateGroundTruth(double stylusLength, double markerRadius,
 
   // Compute tip position in marker coordinates
   // The marker origin is at perpendicular distance markerRadius from the spin axis
-  const double h = std::sqrt(stylusLength * stylusLength - markerRadius * markerRadius);
   const vtkVector3d perpDir = GenerateRandomPerpendicularDirection(spinAxis, rng);
-  const vtkVector3d tipPosition_Marker = h * spinAxis + markerRadius * perpDir;
+  const vtkVector3d tipPosition_Marker = stylusLength * spinAxis + markerRadius * perpDir;
 
   GroundTruth gt;
   gt.TipPosition_World = vtkVector3d(dist(rng), dist(rng), dist(rng));

--- a/IGSIOCalibration/vtkIGSIOSpinCalibrationAlgo.cxx
+++ b/IGSIOCalibration/vtkIGSIOSpinCalibrationAlgo.cxx
@@ -187,7 +187,7 @@ igsioStatus vtkIGSIOSpinCalibrationAlgo::DoSpinCalibrationInternal(const std::ve
   const double tolerance = 1e-9;
   if (minEigenvalue < -tolerance)
   {
-    LOG_WARNING("Expected the minimum eigenvalue of the aggregate instantaneous rotation matrices to be positive. Instead got: " << eigenvalues(0));
+    LOG_WARNING("Expected the minimum eigenvalue of the aggregate instantaneous rotation matrices to be positive. Instead got: " << minEigenvalue);
   }
 
   minEigenvalue = std::max(tolerance, std::abs(minEigenvalue));

--- a/IGSIOCalibration/vtkIGSIOSpinCalibrationAlgo.cxx
+++ b/IGSIOCalibration/vtkIGSIOSpinCalibrationAlgo.cxx
@@ -73,7 +73,7 @@ igsioStatus vtkIGSIOSpinCalibrationAlgo::DoCalibrationInternal(const std::vector
 }
 
 //----------------------------------------------------------------------------
-igsioStatus vtkIGSIOSpinCalibrationAlgo::DoSpinCalibration(vtkIGSIOTransformRepository* aTransformRepository/* = NULL*/, bool snapRotation/*=false*/, bool autoOrient/*=true*/)
+igsioStatus vtkIGSIOSpinCalibrationAlgo::DoSpinCalibration(vtkIGSIOTransformRepository* aTransformRepository /* = NULL*/, bool snapRotation /*=false*/, bool autoOrient /*=true*/)
 {
   if (!this->PivotPointToMarkerTransformMatrix)
   {
@@ -83,7 +83,8 @@ igsioStatus vtkIGSIOSpinCalibrationAlgo::DoSpinCalibration(vtkIGSIOTransformRepo
 
   std::vector<vtkMatrix4x4*> markerToTransformMatrixArray = this->GetAllMarkerToReferenceMatrices();
 
-  igsioStatus error = this->DoSpinCalibrationInternal(markerToTransformMatrixArray, snapRotation, autoOrient, this->PivotPointToMarkerTransformMatrix, this->SpinCalibrationErrorMm);
+  igsioStatus error =
+    this->DoSpinCalibrationInternal(markerToTransformMatrixArray, snapRotation, autoOrient, this->PivotPointToMarkerTransformMatrix, this->SpinCalibrationErrorMm);
   if (error != IGSIO_SUCCESS)
   {
     return IGSIO_FAIL;
@@ -99,7 +100,11 @@ igsioStatus vtkIGSIOSpinCalibrationAlgo::DoSpinCalibration(vtkIGSIOTransformRepo
 }
 
 //----------------------------------------------------------------------------
-igsioStatus vtkIGSIOSpinCalibrationAlgo::DoSpinCalibrationInternal(const std::vector<vtkMatrix4x4*>& markerToTransformMatrixArray, bool snapRotation, bool autoOrient, vtkMatrix4x4* toolTipToToolMatrix, double& error)
+igsioStatus vtkIGSIOSpinCalibrationAlgo::DoSpinCalibrationInternal(const std::vector<vtkMatrix4x4*>& markerToTransformMatrixArray,
+                                                                   bool snapRotation,
+                                                                   bool autoOrient,
+                                                                   vtkMatrix4x4* toolTipToToolMatrix,
+                                                                   double& error)
 {
   if (markerToTransformMatrixArray.size() < 10)
   {
@@ -121,8 +126,8 @@ igsioStatus vtkIGSIOSpinCalibrationAlgo::DoSpinCalibrationInternal(const std::ve
 
   vnl_matrix<double> RI(rows, columns);
 
-  std::vector< vtkMatrix4x4* >::const_iterator previt = markerToTransformMatrixArray.end();
-  for (std::vector< vtkMatrix4x4* >::const_iterator it = markerToTransformMatrixArray.begin(); it != markerToTransformMatrixArray.end(); it++)
+  std::vector<vtkMatrix4x4*>::const_iterator previt = markerToTransformMatrixArray.end();
+  for (std::vector<vtkMatrix4x4*>::const_iterator it = markerToTransformMatrixArray.begin(); it != markerToTransformMatrixArray.end(); it++)
   {
     if (previt == markerToTransformMatrixArray.end())
     {
@@ -130,10 +135,10 @@ igsioStatus vtkIGSIOSpinCalibrationAlgo::DoSpinCalibrationInternal(const std::ve
       continue; // No comparison to make for the first matrix
     }
 
-    vtkSmartPointer< vtkMatrix4x4 > itinverse = vtkSmartPointer< vtkMatrix4x4 >::New();
+    vtkSmartPointer<vtkMatrix4x4> itinverse = vtkSmartPointer<vtkMatrix4x4>::New();
     vtkMatrix4x4::Invert((*it), itinverse);
 
-    vtkSmartPointer< vtkMatrix4x4 > instRotation = vtkSmartPointer< vtkMatrix4x4 >::New();
+    vtkSmartPointer<vtkMatrix4x4> instRotation = vtkSmartPointer<vtkMatrix4x4>::New();
     vtkMatrix4x4::Multiply4x4(itinverse, (*previt), instRotation);
 
     for (int i = 0; i < 3; i++)
@@ -176,11 +181,19 @@ igsioStatus vtkIGSIOSpinCalibrationAlgo::DoSpinCalibrationInternal(const std::ve
     shaftAxis_ToolTip.put(closestCoordinateAxis, 1); // Doesn't matter the direction, will be sorted out later
   }
 
+  // Make sure that the minimum eigenvalue is positive
+  double minEigenvalue = eigenvalues(0);
+
+  const double tolerance = 1e-9;
+  if (minEigenvalue < -tolerance)
+  {
+    LOG_WARNING("Expected the minimum eigenvalue of the aggregate instantaneous rotation matrices to be positive. Instead got: " << eigenvalues(0));
+  }
+
+  minEigenvalue = std::max(tolerance, std::abs(minEigenvalue));
+
   // Set the RMSE
-  // "A" is a positive semidefinite matrix by construction (as it's the summation of positive semidefinite matrices in the form R^t * R)
-  // This means that all eigenvalues have to be >= 0. But due to precision errors in vnl_symmetric_eigensystem_compute, a negative eigenvalue
-  // might be computed that is very close to zero. So we just approximate them to zero.
-  error = sqrt(std::max(eigenvalues(0), 0.0) / markerToTransformMatrixArray.size());
+  error = sqrt(minEigenvalue / markerToTransformMatrixArray.size());
   // Note: This error is the RMS distance from the ideal axis of rotation to the axis of rotation for each instantaneous rotation
   // This RMS distance can be computed to an angle in the following way: angle = arccos( 1 - SpinRMSE^2 / 2 )
   // Here we elect to return the RMS distance because this is the quantity that was actually minimized in the calculation

--- a/IGSIOCalibration/vtkIGSIOSpinCalibrationAlgo.cxx
+++ b/IGSIOCalibration/vtkIGSIOSpinCalibrationAlgo.cxx
@@ -73,7 +73,7 @@ igsioStatus vtkIGSIOSpinCalibrationAlgo::DoCalibrationInternal(const std::vector
 }
 
 //----------------------------------------------------------------------------
-igsioStatus vtkIGSIOSpinCalibrationAlgo::DoSpinCalibration(vtkIGSIOTransformRepository* aTransformRepository /* = NULL*/, bool snapRotation /*=false*/, bool autoOrient /*=true*/)
+igsioStatus vtkIGSIOSpinCalibrationAlgo::DoSpinCalibration(vtkIGSIOTransformRepository* aTransformRepository/* = NULL*/, bool snapRotation/*=false*/, bool autoOrient/*=true*/)
 {
   if (!this->PivotPointToMarkerTransformMatrix)
   {
@@ -83,8 +83,7 @@ igsioStatus vtkIGSIOSpinCalibrationAlgo::DoSpinCalibration(vtkIGSIOTransformRepo
 
   std::vector<vtkMatrix4x4*> markerToTransformMatrixArray = this->GetAllMarkerToReferenceMatrices();
 
-  igsioStatus error =
-    this->DoSpinCalibrationInternal(markerToTransformMatrixArray, snapRotation, autoOrient, this->PivotPointToMarkerTransformMatrix, this->SpinCalibrationErrorMm);
+  igsioStatus error = this->DoSpinCalibrationInternal(markerToTransformMatrixArray, snapRotation, autoOrient, this->PivotPointToMarkerTransformMatrix, this->SpinCalibrationErrorMm);
   if (error != IGSIO_SUCCESS)
   {
     return IGSIO_FAIL;
@@ -100,11 +99,7 @@ igsioStatus vtkIGSIOSpinCalibrationAlgo::DoSpinCalibration(vtkIGSIOTransformRepo
 }
 
 //----------------------------------------------------------------------------
-igsioStatus vtkIGSIOSpinCalibrationAlgo::DoSpinCalibrationInternal(const std::vector<vtkMatrix4x4*>& markerToTransformMatrixArray,
-                                                                   bool snapRotation,
-                                                                   bool autoOrient,
-                                                                   vtkMatrix4x4* toolTipToToolMatrix,
-                                                                   double& error)
+igsioStatus vtkIGSIOSpinCalibrationAlgo::DoSpinCalibrationInternal(const std::vector<vtkMatrix4x4*>& markerToTransformMatrixArray, bool snapRotation, bool autoOrient, vtkMatrix4x4* toolTipToToolMatrix, double& error)
 {
   if (markerToTransformMatrixArray.size() < 10)
   {
@@ -126,8 +121,8 @@ igsioStatus vtkIGSIOSpinCalibrationAlgo::DoSpinCalibrationInternal(const std::ve
 
   vnl_matrix<double> RI(rows, columns);
 
-  std::vector<vtkMatrix4x4*>::const_iterator previt = markerToTransformMatrixArray.end();
-  for (std::vector<vtkMatrix4x4*>::const_iterator it = markerToTransformMatrixArray.begin(); it != markerToTransformMatrixArray.end(); it++)
+  std::vector< vtkMatrix4x4* >::const_iterator previt = markerToTransformMatrixArray.end();
+  for (std::vector< vtkMatrix4x4* >::const_iterator it = markerToTransformMatrixArray.begin(); it != markerToTransformMatrixArray.end(); it++)
   {
     if (previt == markerToTransformMatrixArray.end())
     {
@@ -135,10 +130,10 @@ igsioStatus vtkIGSIOSpinCalibrationAlgo::DoSpinCalibrationInternal(const std::ve
       continue; // No comparison to make for the first matrix
     }
 
-    vtkSmartPointer<vtkMatrix4x4> itinverse = vtkSmartPointer<vtkMatrix4x4>::New();
+    vtkSmartPointer< vtkMatrix4x4 > itinverse = vtkSmartPointer< vtkMatrix4x4 >::New();
     vtkMatrix4x4::Invert((*it), itinverse);
 
-    vtkSmartPointer<vtkMatrix4x4> instRotation = vtkSmartPointer<vtkMatrix4x4>::New();
+    vtkSmartPointer< vtkMatrix4x4 > instRotation = vtkSmartPointer< vtkMatrix4x4 >::New();
     vtkMatrix4x4::Multiply4x4(itinverse, (*previt), instRotation);
 
     for (int i = 0; i < 3; i++)

--- a/IGSIOCalibration/vtkIGSIOSpinCalibrationAlgo.cxx
+++ b/IGSIOCalibration/vtkIGSIOSpinCalibrationAlgo.cxx
@@ -73,7 +73,7 @@ igsioStatus vtkIGSIOSpinCalibrationAlgo::DoCalibrationInternal(const std::vector
 }
 
 //----------------------------------------------------------------------------
-igsioStatus vtkIGSIOSpinCalibrationAlgo::DoSpinCalibration(vtkIGSIOTransformRepository* aTransformRepository/* = NULL*/, bool snapRotation/*=false*/, bool autoOrient/*=true*/)
+igsioStatus vtkIGSIOSpinCalibrationAlgo::DoSpinCalibration(vtkIGSIOTransformRepository* aTransformRepository /* = NULL*/, bool snapRotation /*=false*/, bool autoOrient /*=true*/)
 {
   if (!this->PivotPointToMarkerTransformMatrix)
   {
@@ -83,7 +83,8 @@ igsioStatus vtkIGSIOSpinCalibrationAlgo::DoSpinCalibration(vtkIGSIOTransformRepo
 
   std::vector<vtkMatrix4x4*> markerToTransformMatrixArray = this->GetAllMarkerToReferenceMatrices();
 
-  igsioStatus error = this->DoSpinCalibrationInternal(markerToTransformMatrixArray, snapRotation, autoOrient, this->PivotPointToMarkerTransformMatrix, this->SpinCalibrationErrorMm);
+  igsioStatus error =
+    this->DoSpinCalibrationInternal(markerToTransformMatrixArray, snapRotation, autoOrient, this->PivotPointToMarkerTransformMatrix, this->SpinCalibrationErrorMm);
   if (error != IGSIO_SUCCESS)
   {
     return IGSIO_FAIL;
@@ -99,7 +100,11 @@ igsioStatus vtkIGSIOSpinCalibrationAlgo::DoSpinCalibration(vtkIGSIOTransformRepo
 }
 
 //----------------------------------------------------------------------------
-igsioStatus vtkIGSIOSpinCalibrationAlgo::DoSpinCalibrationInternal(const std::vector<vtkMatrix4x4*>& markerToTransformMatrixArray, bool snapRotation, bool autoOrient, vtkMatrix4x4* toolTipToToolMatrix, double& error)
+igsioStatus vtkIGSIOSpinCalibrationAlgo::DoSpinCalibrationInternal(const std::vector<vtkMatrix4x4*>& markerToTransformMatrixArray,
+                                                                   bool snapRotation,
+                                                                   bool autoOrient,
+                                                                   vtkMatrix4x4* toolTipToToolMatrix,
+                                                                   double& error)
 {
   if (markerToTransformMatrixArray.size() < 10)
   {
@@ -121,8 +126,8 @@ igsioStatus vtkIGSIOSpinCalibrationAlgo::DoSpinCalibrationInternal(const std::ve
 
   vnl_matrix<double> RI(rows, columns);
 
-  std::vector< vtkMatrix4x4* >::const_iterator previt = markerToTransformMatrixArray.end();
-  for (std::vector< vtkMatrix4x4* >::const_iterator it = markerToTransformMatrixArray.begin(); it != markerToTransformMatrixArray.end(); it++)
+  std::vector<vtkMatrix4x4*>::const_iterator previt = markerToTransformMatrixArray.end();
+  for (std::vector<vtkMatrix4x4*>::const_iterator it = markerToTransformMatrixArray.begin(); it != markerToTransformMatrixArray.end(); it++)
   {
     if (previt == markerToTransformMatrixArray.end())
     {
@@ -130,10 +135,10 @@ igsioStatus vtkIGSIOSpinCalibrationAlgo::DoSpinCalibrationInternal(const std::ve
       continue; // No comparison to make for the first matrix
     }
 
-    vtkSmartPointer< vtkMatrix4x4 > itinverse = vtkSmartPointer< vtkMatrix4x4 >::New();
+    vtkSmartPointer<vtkMatrix4x4> itinverse = vtkSmartPointer<vtkMatrix4x4>::New();
     vtkMatrix4x4::Invert((*it), itinverse);
 
-    vtkSmartPointer< vtkMatrix4x4 > instRotation = vtkSmartPointer< vtkMatrix4x4 >::New();
+    vtkSmartPointer<vtkMatrix4x4> instRotation = vtkSmartPointer<vtkMatrix4x4>::New();
     vtkMatrix4x4::Multiply4x4(itinverse, (*previt), instRotation);
 
     for (int i = 0; i < 3; i++)
@@ -176,8 +181,11 @@ igsioStatus vtkIGSIOSpinCalibrationAlgo::DoSpinCalibrationInternal(const std::ve
     shaftAxis_ToolTip.put(closestCoordinateAxis, 1); // Doesn't matter the direction, will be sorted out later
   }
 
-  //set the RMSE
-  error = sqrt(eigenvalues(0) / markerToTransformMatrixArray.size());
+  // Set the RMSE
+  // "A" is a positive semidefinite matrix by construction (as it's the summation of positive semidefinite matrices in the form R^t * R)
+  // This means that all eigenvalues have to be >= 0. But due to precision errors in vnl_symmetric_eigensystem_compute, a negative eigenvalue
+  // might be computed that is very close to zero. So we just approximate them to zero.
+  error = sqrt(std::max(eigenvalues(0), 0.0) / markerToTransformMatrixArray.size());
   // Note: This error is the RMS distance from the ideal axis of rotation to the axis of rotation for each instantaneous rotation
   // This RMS distance can be computed to an angle in the following way: angle = arccos( 1 - SpinRMSE^2 / 2 )
   // Here we elect to return the RMS distance because this is the quantity that was actually minimized in the calculation

--- a/IGSIOCalibration/vtkIGSIOSpinCalibrationAlgo.cxx
+++ b/IGSIOCalibration/vtkIGSIOSpinCalibrationAlgo.cxx
@@ -73,7 +73,7 @@ igsioStatus vtkIGSIOSpinCalibrationAlgo::DoCalibrationInternal(const std::vector
 }
 
 //----------------------------------------------------------------------------
-igsioStatus vtkIGSIOSpinCalibrationAlgo::DoSpinCalibration(vtkIGSIOTransformRepository* aTransformRepository /* = NULL*/, bool snapRotation /*=false*/, bool autoOrient /*=true*/)
+igsioStatus vtkIGSIOSpinCalibrationAlgo::DoSpinCalibration(vtkIGSIOTransformRepository* aTransformRepository/* = NULL*/, bool snapRotation/*=false*/, bool autoOrient/*=true*/)
 {
   if (!this->PivotPointToMarkerTransformMatrix)
   {
@@ -83,8 +83,7 @@ igsioStatus vtkIGSIOSpinCalibrationAlgo::DoSpinCalibration(vtkIGSIOTransformRepo
 
   std::vector<vtkMatrix4x4*> markerToTransformMatrixArray = this->GetAllMarkerToReferenceMatrices();
 
-  igsioStatus error =
-    this->DoSpinCalibrationInternal(markerToTransformMatrixArray, snapRotation, autoOrient, this->PivotPointToMarkerTransformMatrix, this->SpinCalibrationErrorMm);
+  igsioStatus error = this->DoSpinCalibrationInternal(markerToTransformMatrixArray, snapRotation, autoOrient, this->PivotPointToMarkerTransformMatrix, this->SpinCalibrationErrorMm);
   if (error != IGSIO_SUCCESS)
   {
     return IGSIO_FAIL;
@@ -100,11 +99,7 @@ igsioStatus vtkIGSIOSpinCalibrationAlgo::DoSpinCalibration(vtkIGSIOTransformRepo
 }
 
 //----------------------------------------------------------------------------
-igsioStatus vtkIGSIOSpinCalibrationAlgo::DoSpinCalibrationInternal(const std::vector<vtkMatrix4x4*>& markerToTransformMatrixArray,
-                                                                   bool snapRotation,
-                                                                   bool autoOrient,
-                                                                   vtkMatrix4x4* toolTipToToolMatrix,
-                                                                   double& error)
+igsioStatus vtkIGSIOSpinCalibrationAlgo::DoSpinCalibrationInternal(const std::vector<vtkMatrix4x4*>& markerToTransformMatrixArray, bool snapRotation, bool autoOrient, vtkMatrix4x4* toolTipToToolMatrix, double& error)
 {
   if (markerToTransformMatrixArray.size() < 10)
   {
@@ -126,8 +121,8 @@ igsioStatus vtkIGSIOSpinCalibrationAlgo::DoSpinCalibrationInternal(const std::ve
 
   vnl_matrix<double> RI(rows, columns);
 
-  std::vector<vtkMatrix4x4*>::const_iterator previt = markerToTransformMatrixArray.end();
-  for (std::vector<vtkMatrix4x4*>::const_iterator it = markerToTransformMatrixArray.begin(); it != markerToTransformMatrixArray.end(); it++)
+  std::vector< vtkMatrix4x4* >::const_iterator previt = markerToTransformMatrixArray.end();
+  for (std::vector< vtkMatrix4x4* >::const_iterator it = markerToTransformMatrixArray.begin(); it != markerToTransformMatrixArray.end(); it++)
   {
     if (previt == markerToTransformMatrixArray.end())
     {
@@ -135,10 +130,10 @@ igsioStatus vtkIGSIOSpinCalibrationAlgo::DoSpinCalibrationInternal(const std::ve
       continue; // No comparison to make for the first matrix
     }
 
-    vtkSmartPointer<vtkMatrix4x4> itinverse = vtkSmartPointer<vtkMatrix4x4>::New();
+    vtkSmartPointer< vtkMatrix4x4 > itinverse = vtkSmartPointer< vtkMatrix4x4 >::New();
     vtkMatrix4x4::Invert((*it), itinverse);
 
-    vtkSmartPointer<vtkMatrix4x4> instRotation = vtkSmartPointer<vtkMatrix4x4>::New();
+    vtkSmartPointer< vtkMatrix4x4 > instRotation = vtkSmartPointer< vtkMatrix4x4 >::New();
     vtkMatrix4x4::Multiply4x4(itinverse, (*previt), instRotation);
 
     for (int i = 0; i < 3; i++)
@@ -181,19 +176,14 @@ igsioStatus vtkIGSIOSpinCalibrationAlgo::DoSpinCalibrationInternal(const std::ve
     shaftAxis_ToolTip.put(closestCoordinateAxis, 1); // Doesn't matter the direction, will be sorted out later
   }
 
-  // Make sure that the minimum eigenvalue is positive
-  double minEigenvalue = eigenvalues(0);
-
   const double tolerance = 1e-9;
-  if (minEigenvalue < -tolerance)
-  {
+  const double minEigenvalue = eigenvalues(0);
+  if (minEigenvalue < -tolerance) {
     LOG_WARNING("Expected the minimum eigenvalue of the aggregate instantaneous rotation matrices to be positive. Instead got: " << minEigenvalue);
   }
 
-  minEigenvalue = std::max(tolerance, std::abs(minEigenvalue));
-
-  // Set the RMSE
-  error = sqrt(minEigenvalue / markerToTransformMatrixArray.size());
+  //set the RMSE
+  error = sqrt(std::max(std::abs(minEigenvalue), tolerance) / markerToTransformMatrixArray.size());
   // Note: This error is the RMS distance from the ideal axis of rotation to the axis of rotation for each instantaneous rotation
   // This RMS distance can be computed to an angle in the following way: angle = arccos( 1 - SpinRMSE^2 / 2 )
   // Here we elect to return the RMS distance because this is the quantity that was actually minimized in the calculation


### PR DESCRIPTION
I'm working on a project that uses IGSIO, and I wrote some tests to make sure that calibration works as expected. Thought I would share them with you as well.

Both tests randomly generate transformations according to a "ground truth".

For pivot calibration, the ground truth is the tip position in world coordinates (should be fixed), and the position of the marker in marker coordinates (which will be mapped to -Z direction as stated in the docs). The tests work as follows:
1. Generate marker transforms by:
    * Applying a small random noise to the pivot to mimic non steady surface / hand.
    * Sample a random point on the sphere whose center is the perturbed pivot, and its radius is the stylus length. This point is the marker position.
    * Create a transform according the new pivot and marker positions.
2. Feed these transforms to the algo
3. Make sure that the computed pivot position is as close as possible to the ground truth pivot position.

For spin calibration, the ground truth is the tip position in world coordinates (fixed), the spin axis (which should be calculated), and the distance between the marker and the spin axis. The tests work as follows:
1. Generate marker transforms by:
    * Generating an initial random marker transform
    * Make two revolutions around the spin axis starting from the initial marker transform
    * Add random rotation perturbation to each transform around an axis different than the spin axis
2. Feed these transforms to the algo
3. Make sure that the angle between the computed spin axis, and the ground truth spin axis is as small as possible.