### PR TITLE
COMP: Include the iostream header where cout/cerr used

### DIFF
--- a/IGSIOCommon/vtkIGSIOLogger.cxx
+++ b/IGSIOCommon/vtkIGSIOLogger.cxx
@@ -21,6 +21,8 @@ See License.txt for details.
 
 #include "vtksys/SystemTools.hxx"
 
+// STD includes
+#include <iostream>
 #include <sstream>
 #include <string>
 #include <algorithm>

--- a/SequenceIO/vtkIGSIOMetaImageSequenceIO.cxx
+++ b/SequenceIO/vtkIGSIOMetaImageSequenceIO.cxx
@@ -367,7 +367,7 @@ igsioStatus vtkIGSIOMetaImageSequenceIO::ReadImagePixels()
     }
     catch (std::bad_alloc& e)
     {
-      cerr << e.what() << endl;
+      std::cerr << e.what() << endl;
       LOG_ERROR("vtkIGSIOMetaImageSequenceIO::ReadImagePixels failed due to out of memory. Try to reduce image buffer sizes or use a 64-bit build of Plus.");
       return IGSIO_FAIL;
     }

--- a/VolumeReconstruction/vtkIGSIOVolumeReconstructor.cxx
+++ b/VolumeReconstruction/vtkIGSIOVolumeReconstructor.cxx
@@ -31,6 +31,9 @@
 #include <vtkTransform.h>
 #include <vtkXMLUtilities.h>
 
+// STD includes
+#include <iostream>
+
 vtkStandardNewMacro(vtkIGSIOVolumeReconstructor);
 
 //----------------------------------------------------------------------------
@@ -460,7 +463,7 @@ igsioStatus vtkIGSIOVolumeReconstructor::SetOutputExtentFromFrameList(vtkIGSIOTr
   }
   catch (std::bad_alloc& e)
   {
-    cerr << e.what() << endl;
+    std::cerr << e.what() << endl;
     errorDescription = "StartReconstruction failed due to out of memory. Try to reduce the size or increase spacing of the output volume.";
     LOG_ERROR(errorDescription);
     return IGSIO_FAIL;


### PR DESCRIPTION
This change is necessary to be compatible with VTK 9.6 code as iostream was removed from a core header file as seen in https://github.com/Kitware/VTK/commit/a95326aef076dd9fc6d7329d5fb54f1015ca59b9. See release note https://github.com/Kitware/VTK/commit/7462a8b1411a78f470ca459a34cf1ef2e7c353a8.

This was originally caught by observing build errors for SlicerIGSIO extension which builds IGSIO as a component.
https://slicer.cdash.org/builds/4143726/errors

cc: @Sunderlandkyl 