### PR TITLE
COMP: Fix CMake install step for vtkAddon include

### DIFF
--- a/SuperBuild/External_vtkAddon.cmake
+++ b/SuperBuild/External_vtkAddon.cmake
@@ -75,6 +75,12 @@ else()
     #--Build step-----------------
     BUILD_ALWAYS 1
     #--Install step-----------------
+    INSTALL_COMMAND
+      ${CMAKE_COMMAND} --build . --target install
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        "${CMAKE_BINARY_DIR}/vtkAddon-bin/vtkAddonTargets.cmake"
+        "${CMAKE_BINARY_DIR}/vtkAddon-install/lib/cmake/vtkAddon/vtkAddonTargets.cmake"
+    #--Dependencies-----------------
     DEPENDS ${IGSIO_DEPENDENCIES}
     )
 endif()


### PR DESCRIPTION
@jamesobutler @Sunderlandkyl 

I needed to add a custom install step for vtkAddon when compiling a custom Slicer application in linux.

My specs are:
Ubuntu 25.10
ccmake version 3.31.8
gcc 15.2.0

can you please double check? thanks in advance!