### PR TITLE
COMP: Add missing <iostream> includes (VTK 9.6 compatibility)

### DIFF
--- a/IGSIOCommon/Testing/AccurateTimerTest.cxx
+++ b/IGSIOCommon/Testing/AccurateTimerTest.cxx
@@ -8,6 +8,7 @@
 // On Windows also test if the timings are accurate enough
 
 #include <vtkSmartPointer.h>
+#include <iostream>
 #include <time.h>
 #include "vtksys/CommandLineArguments.hxx"
 #include "vtkMultiThreader.h"

--- a/IGSIOCommon/Testing/igsioCommonTest.cxx
+++ b/IGSIOCommon/Testing/igsioCommonTest.cxx
@@ -6,6 +6,7 @@ See License.txt for details.
 
 // Local includes
 #include "vtkIGSIORecursiveCriticalSection.h"
+#include <iostream>
 #include "igsioCommon.h"
 #include "igsioXmlUtils.h"
 

--- a/IGSIOCommon/Testing/igsioMathTest.cxx
+++ b/IGSIOCommon/Testing/igsioMathTest.cxx
@@ -6,6 +6,7 @@
 
 
 #include <deque>
+#include <iostream>
 
 #include "vtkDebugLeaksManager.h"
 #include "vtkSystemIncludes.h"

--- a/IGSIOCommon/Testing/vtkIGSIOLoggerTest.cxx
+++ b/IGSIOCommon/Testing/vtkIGSIOLoggerTest.cxx
@@ -5,6 +5,7 @@
 =========================================================Plus=header=end*/
 
 #include <vtkObject.h>
+#include <iostream>
 #include "vtksys/CommandLineArguments.hxx"
 #include "vtkSmartPointer.h"
 

--- a/IGSIOCommon/Testing/vtkTransformRepositoryTest.cxx
+++ b/IGSIOCommon/Testing/vtkTransformRepositoryTest.cxx
@@ -5,6 +5,7 @@
 =========================================================Plus=header=end*/
 
 #include "igsioCommon.h"
+#include <iostream>
 #include "vtksys/CommandLineArguments.hxx"
 #include "vtkSmartPointer.h"
 #include "vtkTransform.h"

--- a/IGSIOCommon/igsioCommon.cxx
+++ b/IGSIOCommon/igsioCommon.cxx
@@ -6,6 +6,7 @@ See License.txt for details.
 
 // Local includes
 #include "igsioCommon.h"
+#include <iostream>
 #include "igsioTrackedFrame.h"
 #include "vtkIGSIOTrackedFrameList.h"
 #include "vtkIGSIOAccurateTimer.h"

--- a/IGSIOCommon/igsioMath.cxx
+++ b/IGSIOCommon/igsioMath.cxx
@@ -6,6 +6,7 @@
 
 // IGSIO includes
 #include "igsioMath.h"
+#include <iostream>
 
 // VNL includes
 #include "vnl/vnl_sparse_matrix.h"

--- a/IGSIOCommon/igsioVideoFrame.cxx
+++ b/IGSIOCommon/igsioVideoFrame.cxx
@@ -7,6 +7,7 @@ See License.txt for details.
 // Local includes
 //#include "PlusConfigure.h"
 #include "igsioVideoFrame.h"
+#include <iostream>
 
 // VTK includes
 #include <vtkBMPReader.h>

--- a/IGSIOCommon/vtkIGSIOTrackedFrameList.cxx
+++ b/IGSIOCommon/vtkIGSIOTrackedFrameList.cxx
@@ -6,6 +6,7 @@
 
 // IGSIO includes
 #include "igsioMath.h"
+#include <iostream>
 #include "igsioTrackedFrame.h"
 #include "vtkIGSIOTrackedFrameList.h"
 #include "vtkIGSIOTransformRepository.h"

--- a/SequenceIO/Testing/vtkMetaImageSequenceIOTest.cxx
+++ b/SequenceIO/Testing/vtkMetaImageSequenceIOTest.cxx
@@ -6,6 +6,7 @@ See License.txt for details.
 
 //#include "PlusConfigure.h"
 #include "vtksys/CommandLineArguments.hxx"
+#include <iostream>
 #include <iomanip>
 
 #include "vtkSmartPointer.h"

--- a/SequenceIO/Testing/vtkMkvSequenceIOTest.cxx
+++ b/SequenceIO/Testing/vtkMkvSequenceIOTest.cxx
@@ -6,6 +6,7 @@ See License.txt for details.
 
 // std includes
 #include <iomanip>
+#include <iostream>
 
 // VTK includes
 #include <vtkMatrix4x4.h>

--- a/SequenceIO/vtkIGSIOSequenceIOBase.cxx
+++ b/SequenceIO/vtkIGSIOSequenceIOBase.cxx
@@ -6,6 +6,7 @@ See License.txt for details.
 
 //#include "PlusConfigure.h"
 #include "vtkObjectFactory.h"
+#include <iostream>
 #include "vtkIGSIOSequenceIOBase.h"
 #include "vtkIGSIOTrackedFrameList.h"
 #include "vtksys/Encoding.hxx"

--- a/VolumeReconstruction/Testing/VolumeReconstructorTest.cxx
+++ b/VolumeReconstruction/Testing/VolumeReconstructorTest.cxx
@@ -5,6 +5,7 @@
 =========================================================IGSIO=header=end*/
 
 #include "igsioConfigure.h"
+#include <iostream>
 #include "igsioTrackedFrame.h"
 #include "igsioXmlUtils.h"
 #include "vtkImageData.h"

--- a/VolumeReconstruction/vtkIGSIOPasteSliceIntoVolume.cxx
+++ b/VolumeReconstruction/vtkIGSIOPasteSliceIntoVolume.cxx
@@ -41,6 +41,7 @@ POSSIBILITY OF SUCH DAMAGES.
 =========================================================================*/
 
 #include "igsioConfigure.h"
+#include <iostream>
 
 // VTK includes
 #include <vtkDataArray.h>


### PR DESCRIPTION
Sources that use `std::cout`/`std::cerr`/`std::endl` relied on a transitive `<iostream>` from `vtkSystemIncludes.h`. VTK 9.6 no longer pulls in `<iostream>` there, so these translation units fail to compile against newer VTK (`'cerr' is not a member of 'std'`). This includes `<iostream>` directly where it is used (include-what-you-use).

Header-only change — no functional or API impact, and compatible with all supported ITK/VTK versions (including ITK 5.4.6 and its companion VTK, where the include is simply redundant-but-harmless).

<details>
<summary>Files (14)</summary>

`IGSIOCommon/{igsioMath,igsioVideoFrame,igsioCommon,vtkIGSIOTrackedFrameList}.cxx`, `IGSIOCommon/Testing/{vtkIGSIOLoggerTest,AccurateTimerTest,igsioCommonTest,vtkTransformRepositoryTest,igsioMathTest}.cxx`, `SequenceIO/vtkIGSIOSequenceIOBase.cxx`, `SequenceIO/Testing/{vtkMkvSequenceIOTest,vtkMetaImageSequenceIOTest}.cxx`, `VolumeReconstruction/vtkIGSIOPasteSliceIntoVolume.cxx`, `VolumeReconstruction/Testing/VolumeReconstructorTest.cxx`
</details>
