### PR TITLE
COMP: Fix build with newer OpenCL C++ bindings (e.g. CUDA 12.x)

### DIFF
--- a/VolumeReconstruction/vtkIGSIOPasteSliceIntoVolumeHelperOpenCL.h
+++ b/VolumeReconstruction/vtkIGSIOPasteSliceIntoVolumeHelperOpenCL.h
@@ -55,6 +55,10 @@ POSSIBILITY OF SUCH DAMAGES.
 
 #include "vtkIGSIOPasteSliceIntoVolumeHelperCommon.h"
 
+// Newer OpenCL C++ bindings (as shipped e.g. with recent CUDA toolkits) gate the
+// deprecated cl::size_t<N> compatibility class used below behind this macro.
+#define CL_HPP_ENABLE_SIZE_T_COMPATIBILITY
+
 #ifdef __APPLE__
 #include <OpenCL/cl.hpp>
 #else


### PR DESCRIPTION
Recent Khronos OpenCL-CLHPP headers (as bundled with recent CUDA toolkits) gate the deprecated cl::size_t<N> compatibility class behind CL_HPP_ENABLE_SIZE_T_COMPATIBILITY, which was previously undefined here. Without it, cl::size_t<3> is unavailable, causing C2039/C2059/C2065 compile errors in vtkIGSIOPasteSliceIntoVolumeHelperOpenCL.h.